### PR TITLE
feat(state): add Zustand oceanStore with robots array

### DIFF
--- a/src/stores/oceanStore.ts
+++ b/src/stores/oceanStore.ts
@@ -1,0 +1,60 @@
+// ========================================
+// IMPORTS
+// ========================================
+import { create } from 'zustand';
+
+// ========================================
+// TYPES
+// ========================================
+export interface Robot {
+  id: string;
+  // Add more robot fields as needed
+}
+
+interface OceanStore {
+  robots: Robot[];
+  settings: {
+    bpm: number;
+    maxRobots: number;
+  };
+  addRobot: (robot: Robot) => void;
+  removeRobot: (id: string) => void;
+  updateRobot: (robot: Robot) => void;
+}
+
+// ========================================
+// CONSTANTS
+// ========================================
+const INITIAL_SETTINGS = {
+  bpm: 60,
+  maxRobots: 12,
+};
+
+// ========================================
+// STORE
+// ========================================
+export const useOceanStore = create<OceanStore>((set, get) => ({
+  robots: [],
+  settings: { ...INITIAL_SETTINGS },
+  addRobot: (robot) => {
+    // Stub: log only for now
+    console.log('[OceanStore] addRobot called', robot);
+    // Implementation to be added in future milestones
+  },
+  removeRobot: (id) => {
+    // Stub: log only for now
+    console.log('[OceanStore] removeRobot called', id);
+    // Implementation to be added in future milestones
+  },
+  updateRobot: (robot) => {
+    // Stub: log only for now
+    console.log('[OceanStore] updateRobot called', robot);
+    // Implementation to be added in future milestones
+  },
+}));
+
+// ========================================
+// NOTES
+// ========================================
+// See: https://github.com/Fallboard-Studios/pelagos-7/issues/8
+// Docs: docs/ARCHITECTURE.md#state-zustand


### PR DESCRIPTION
## Description

Implements the main Zustand store for managing robot and world state with minimal Robot interface and stub actions (log only per M0 spec).

## Type of Change
- [x] New feature

## Testing
- [x] Tested locally
- [x] TypeScript compiles
- [x] No architectural violations

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed

## Related Issues
Closes #8