### PR TITLE
feat(components): create OceanScene component with SVG canvas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,7 @@
-import { useState } from 'react'
-
-import './App.css'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { OceanScene } from './components/OceanScene';
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  return <OceanScene />;
 }
 
-export default App
+export default App;

--- a/src/components/OceanScene.css
+++ b/src/components/OceanScene.css
@@ -1,0 +1,5 @@
+.ocean-scene {
+  display: block;
+  width: 100%;
+  height: 100vh;
+}

--- a/src/components/OceanScene.tsx
+++ b/src/components/OceanScene.tsx
@@ -1,0 +1,39 @@
+import './OceanScene';
+
+// ========================================
+// TYPES & INTERFACES
+// ========================================
+interface OceanSceneProps {
+  width?: number;
+  height?: number;
+}
+
+// ========================================
+// CONSTANTS
+// ========================================
+const DEFAULT_WIDTH = 1920;
+const DEFAULT_HEIGHT = 1080;
+const BACKGROUND_COLOR = '#0a1128';
+
+// ========================================
+// COMPONENT
+// ========================================
+export function OceanScene({
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+}: OceanSceneProps = {}) {
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="ocean-scene"
+      width={width}
+      height={height}
+    >
+      <rect fill={BACKGROUND_COLOR} width={width} height={height} />
+      <g id="background-layer" />
+      <g id="robot-layer" />
+      <g id="foreground-layer" />
+      <g id="ui-layer" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Description
Creates the main OceanScene component with an empty SVG canvas and responsive viewport. This establishes the foundational rendering layer for robots and environment elements.

## Type of Change
- [x] New feature

## Testing
- [x] Tested locally
- [x] TypeScript compiles
- [x] No architectural violations

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed

## Related Issues
Closes #9