### PR TITLE
chore(eslint): allow console.log in no-console rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,18 +1,18 @@
 import js from '@eslint/js';
-import globals from 'globals';
+import importPlugin from 'eslint-plugin-import';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
+import globals from 'globals';
 import tseslint from 'typescript-eslint';
-import importPlugin from 'eslint-plugin-import';
 
 export default [
   // Ignore build output
   { ignores: ['dist'] },
-  
+
   // Base recommended configs
   js.configs.recommended,
   ...tseslint.configs.recommended,
-  
+
   // React-specific rules
   {
     files: ['**/*.{ts,tsx}'],
@@ -28,21 +28,21 @@ export default [
     rules: {
       // React Hooks rules
       ...reactHooks.configs.recommended.rules,
-      
+
       // React Refresh rules
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },
       ],
-      
+
       // TypeScript rules (from Phase 0)
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/no-unused-vars': ['error', { 
+      '@typescript-eslint/no-unused-vars': ['error', {
         argsIgnorePattern: '^_',
-        varsIgnorePattern: '^_' 
+        varsIgnorePattern: '^_'
       }],
-      
+
       // Import ordering (from Phase 0)
       'import/order': ['error', {
         'groups': [
@@ -53,9 +53,9 @@ export default [
         ],
         'newlines-between': 'always',
       }],
-      
+
       // Console rules (from Phase 0)
-      'no-console': ['warn', { allow: ['warn', 'error'] }],
+      'no-console': ['warn', { allow: ['warn', 'error', 'log'] }],
     },
   },
 ];

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -38,7 +38,6 @@ export const AudioEngine = {
   },
   scheduleNote(params: unknown): void {
     // Stub: log params to console (no audio yet)
-    // eslint-disable-next-line no-console
     console.log('[AudioEngine] scheduleNote called with:', params);
   },
 };

--- a/src/engine/beatClock.ts
+++ b/src/engine/beatClock.ts
@@ -36,7 +36,6 @@ export function initBeatClock(): void {
     currentMeasure = measure;
   }, '16n');
   initialized = true;
-  // eslint-disable-next-line no-console
   console.log('BeatClock initialized');
 }
 
@@ -58,7 +57,6 @@ export function getCurrentMeasure(): number {
  * Stub: schedule a callback at a specific beat (logs only)
  */
 export function scheduleAtBeat(beat: number, callback: () => void): string {
-  // eslint-disable-next-line no-console
   console.log('[BeatClock] scheduleAtBeat (stub):', beat, callback);
   return 'stub-id';
 }
@@ -67,7 +65,6 @@ export function scheduleAtBeat(beat: number, callback: () => void): string {
  * Stub: schedule a repeating callback (logs only)
  */
 export function scheduleRepeat(interval: string, callback: () => void): string {
-  // eslint-disable-next-line no-console
   console.log('[BeatClock] scheduleRepeat (stub):', interval, callback);
   return 'stub-id';
 }

--- a/src/stores/oceanStore.ts
+++ b/src/stores/oceanStore.ts
@@ -33,7 +33,7 @@ const INITIAL_SETTINGS = {
 // ========================================
 // STORE
 // ========================================
-export const useOceanStore = create<OceanStore>((set, get) => ({
+export const useOceanStore = create<OceanStore>((_set, _get) => ({
   robots: [],
   settings: { ...INITIAL_SETTINGS },
   addRobot: (robot) => {


### PR DESCRIPTION
## Description
Updates ESLint configuration to allow `console.log()` in stub implementations, removing unnecessary disable comments and cleaning up lint warnings. Fixes unused parameter warnings in oceanStore.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation

## Testing
- [x] Tested locally
- [x] TypeScript compiles
- [x] No architectural violations

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed