### PR TITLE
feat(components): add PlayButton for audio init

### DIFF
--- a/.github/prompts/new-feature.prompt.md
+++ b/.github/prompts/new-feature.prompt.md
@@ -3,7 +3,7 @@ name: new-feature
 description: Plan and implement a feature from a GitHub issue following project architecture
 agent: agent
 tools:
-  ['read', 'edit', 'search/changes', 'web']
+  ['read', 'edit', 'search/changes', 'web', 'gitkraken/git_branch', 'gitkraken/git_checkout']
 ---
 
 I want to implement a feature from a GitHub issue.

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+assets
 *.local
 
 # Editor directories and files

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,17 @@
+import { useState } from 'react';
+
 import { OceanScene } from './components/OceanScene';
+import { PlayButton } from './components/PlayButton';
 
 function App() {
-  return <OceanScene />;
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  return (
+    <>
+      {!isPlaying && <PlayButton onSuccess={() => setIsPlaying(true)} />}
+      <OceanScene />
+    </>
+  );
 }
 
 export default App;

--- a/src/components/OceanScene.tsx
+++ b/src/components/OceanScene.tsx
@@ -1,4 +1,4 @@
-import './OceanScene';
+import './OceanScene.css';
 
 // ========================================
 // TYPES & INTERFACES

--- a/src/components/PlayButton.css
+++ b/src/components/PlayButton.css
@@ -1,0 +1,44 @@
+.play-button-overlay {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  transform: translate(-50%, -50%);
+}
+
+.play-button {
+  padding: 16px 32px;
+  font-size: 18px;
+  font-weight: 600;
+  color: #ffffff;
+  background-color: #007acc;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  min-width: 240px;
+  text-align: center;
+}
+
+.play-button:hover:not(:disabled) {
+  background-color: #005a9e;
+}
+
+.play-button:focus {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+.play-button:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.play-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}

--- a/src/components/PlayButton.tsx
+++ b/src/components/PlayButton.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+
+import { AudioEngine } from '../engine/AudioEngine';
+
+import './PlayButton.css';
+
+// ========================================
+// TYPES & INTERFACES
+// ========================================
+interface PlayButtonProps {
+  onSuccess?: () => void;
+}
+
+type PlayButtonState = 'idle' | 'loading' | 'error';
+
+// ========================================
+// CONSTANTS
+// ========================================
+const BUTTON_TEXT = {
+  idle: 'Play',
+  loading: 'Starting...',
+  error: 'Audio failed to initialize. Click to retry.',
+};
+
+// ========================================
+// COMPONENT
+// ========================================
+export function PlayButton({ onSuccess }: PlayButtonProps) {
+  const [playState, setPlayState] = useState<PlayButtonState>('idle');
+
+  const handleClick = async () => {
+    setPlayState('loading');
+
+    try {
+      await AudioEngine.start();
+      setPlayState('idle');
+      onSuccess?.();
+    } catch (err) {
+      console.error('[PlayButton] AudioEngine.start() failed:', err);
+      setPlayState('error');
+    }
+  };
+
+  return (
+    <div className="play-button-overlay">
+      <button
+        className="play-button"
+        onClick={handleClick}
+        disabled={playState === 'loading'}
+        aria-label={BUTTON_TEXT[playState]}
+        aria-busy={playState === 'loading'}
+      >
+        {BUTTON_TEXT[playState]}
+      </button>
+    </div>
+  );
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Description
Implements PlayButton component that initializes AudioEngine in compliance with Web Audio browser autoplay policy. Requires explicit user gesture before audio can play, with proper loading and error state handling.

## Type of Change
- [x] New feature

## Testing
- [x] Tested locally
- [x] TypeScript compiles
- [x] No architectural violations

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed

## Related Issues
Closes #10