### PR TITLE
feat(components): integrate robots into OceanScene component

### DIFF
--- a/src/components/OceanScene.tsx
+++ b/src/components/OceanScene.tsx
@@ -1,4 +1,10 @@
+import { useEffect } from 'react';
+
 import './OceanScene.css';
+import { Robot } from './robot/Robot';
+import { useOceanStore } from '../stores/oceanStore';
+import { spawnRobot } from '../systems/spawnSystem';
+import { handleRobotIdle } from '../systems/idleSystem';
 
 // ========================================
 // TYPES & INTERFACES
@@ -22,6 +28,20 @@ export function OceanScene({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
 }: OceanSceneProps = {}) {
+  const robots = useOceanStore((s) => s.robots);
+
+  // Spawn initial robots on mount
+  useEffect(() => {
+    spawnRobot();
+    spawnRobot();
+
+    // Get robots that were just added (synchronous)
+    const currentRobots = useOceanStore.getState().robots;
+    currentRobots.forEach((robot) => {
+      handleRobotIdle(robot.id);
+    });
+  }, []);
+
   return (
     <svg
       viewBox={`0 0 ${width} ${height}`}
@@ -31,7 +51,11 @@ export function OceanScene({
     >
       <rect fill={BACKGROUND_COLOR} width={width} height={height} />
       <g id="background-layer" />
-      <g id="robot-layer" />
+      <g id="robot-layer">
+        {robots.map((robot) => (
+          <Robot key={robot.id} robot={robot} />
+        ))}
+      </g>
       <g id="foreground-layer" />
       <g id="ui-layer" />
     </svg>


### PR DESCRIPTION
## Description
Integrates robots into the OceanScene component, displaying them from the store and initiating autonomous behavior on mount. Robots now spawn and immediately begin swimming to random destinations in an endless loop.

## Type of Change
- [x] New feature

## Testing
- [x] Tested locally (2 robots spawn and begin autonomous movement)
- [x] TypeScript compiles
- [x] No architectural violations (removed setTimeout, uses synchronous store updates)

## Implementation Details
**Changes to OceanScene.tsx:**
- Subscribe to `robots` array from oceanStore (reactive)
- Spawn 2 initial robots on component mount
- Immediately start autonomous idle behavior (`handleRobotIdle`) for spawned robots
- Render robots in `robot-layer` group with proper `robot.id` keys
- Removed unnecessary setTimeout (store updates are synchronous)

**Architecture Compliance:**
- ✅ No setTimeout/setInterval (store updates applied synchronously)
- ✅ Proper separation of concerns (component renders, systems handle logic)
- ✅ Reactive state management (Zustand subscription)

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Robots render from store and update reactively
- [x] No duplicate React keys

## Related Issues
Closes #24