### PR TITLE
feat(audio): add getSynth helper to AudioEngine API

### DIFF
--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -233,4 +233,17 @@ export const AudioEngine = {
       `[AudioEngine] Unregistered melody for robot ${robotId} (${removedCount} events removed)`
     );
   },
+
+  getSynth(type?: string): Tone.PolySynth | null {
+    if (!synthPool) {
+      console.warn('[AudioEngine] Synth pool not loaded');
+      return null;
+    }
+
+    // Map synth type to pool key
+    const poolKey = type as keyof SynthPool;
+
+    // Return requested synth or fall back to default
+    return synthPool[poolKey] ?? synthPool.default;
+  },
 };


### PR DESCRIPTION
## Description
Adds `getSynth()` public method to AudioEngine API, exposing access to the synth pool (default, fm, am, membrane) with fallback behavior. This completes the synth pool infrastructure needed for future per-robot synth type assignment.

## Type of Change
- [x] New feature

## Testing
- [x] TypeScript compiles
- [x] No architectural violations

## Checklist
- [x] Code follows style guidelines

## Related Issues
Closes #27