### PR TITLE
feat(debug): add audio status overlay showing polyphony stats

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { OceanScene } from './components/OceanScene';
 import { PlayButton } from './components/PlayButton';
+import { AudioStatus } from './components/debug/AudioStatus';
 
 function App() {
   const [isAudioReady, setAudioReady] = useState(false);
@@ -10,6 +11,7 @@ function App() {
     <>
       {!isAudioReady && <PlayButton onSuccess={() => setAudioReady(true)} />}
       <OceanScene />
+      <AudioStatus />
     </>
   );
 }

--- a/src/components/debug/AudioStatus.css
+++ b/src/components/debug/AudioStatus.css
@@ -1,0 +1,20 @@
+.audio-status {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  padding: 12px 16px;
+  background: rgba(0, 0, 0, 0.75);
+  color: #ffffff;
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  border-radius: 4px;
+  pointer-events: none;
+  z-index: 9999;
+  user-select: none;
+}
+
+.audio-status div {
+  margin: 0;
+  padding: 0;
+}

--- a/src/components/debug/AudioStatus.tsx
+++ b/src/components/debug/AudioStatus.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+import { useOceanStore } from '../../stores/oceanStore';
+import { AudioEngine } from '../../engine/AudioEngine';
+import { DEV_TUNING } from '../../constants';
+import './AudioStatus.css';
+
+// ========================================
+// TYPES
+// ========================================
+interface PolyphonyStats {
+  voices: number;
+  maxVoices: number;
+  step: number;
+}
+
+// ========================================
+// CONSTANTS
+// ========================================
+const UPDATE_INTERVAL_MS = 100;
+
+// ========================================
+// COMPONENT
+// ========================================
+export function AudioStatus() {
+  const robots = useOceanStore((s) => s.robots);
+  const [stats, setStats] = useState<PolyphonyStats>({
+    voices: 0,
+    maxVoices: 0,
+    step: 0,
+  });
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setStats(AudioEngine.getPolyphonyStats());
+    }, UPDATE_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  if (!DEV_TUNING) return null;
+
+  return (
+    <div className="audio-status">
+      <div>Voices: {stats.voices}/{stats.maxVoices}</div>
+      <div>Robots: {robots.length}</div>
+      <div>Step: {stats.step}/16</div>
+    </div>
+  );
+}

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -282,4 +282,12 @@ export const AudioEngine = {
     // Return requested synth or fall back to default
     return synthPool[poolKey] ?? synthPool.default;
   },
+
+  getPolyphonyStats(): { voices: number; maxVoices: number; step: number } {
+    return {
+      voices: activeVoices,
+      maxVoices: MAX_POLYPHONY,
+      step: (stepCounter % 16) + 1,
+    };
+  },
 };


### PR DESCRIPTION
## Description
Adds real-time audio status overlay for development monitoring. Displays active voice count (polyphony management), registered robot count, and current step in the 16-step melody loop. Gated behind `DEV_TUNING` flag - hidden in production builds.

## Type of Change
- [x] New feature

## Changes Made
- Added `AudioEngine.getPolyphonyStats()` method returning `{ voices, maxVoices, step }`
- Created `AudioStatus` component with 100ms polling interval
- Styled overlay positioned in top-right corner (non-intrusive)
- Integrated into `App.tsx` root component

## Testing
- [x] Tested locally
- [x] TypeScript compiles
- [x] No architectural violations

## Checklist
- [x] Code follows style guidelines (functional component, proper imports ordering, constants extracted)
- [x] Self-review completed
- [x] Component properly gated by `DEV_TUNING` constant

## Related Issues
Closes #30