### PR TITLE
feat(interactions): play note flurry and visuals on collision

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -126,7 +126,7 @@ interface OceanStore {
 interface RobotMelodyEvent {
   id: string;               // crypto.randomUUID()
   startStep: number;        // 1..16 (8th-note grid)
-  length: '8n' | '4n' | '2n';
+  length: '16n' |'8n' | '4n' | '2n';
   noteIndex: number;        // 0..7 -> index into availableNotes[]
 }
 ```

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -3,6 +3,7 @@
 // ========================================
 import * as Tone from 'tone';
 
+import type { NoteDuration } from '../types/Robot';
 import { getAvailableNotes, scheduleHarmonyCycle, stopHarmonyCycle } from './harmonySystem';
 import { initBeatClock } from './beatClock';
 import type { RobotMelodyEvent } from './melodyGenerator';
@@ -14,7 +15,7 @@ import { DEV_TUNING } from '../constants';
 export interface NoteParams {
   robotId: string;
   note: string;
-  duration: '8n' | '4n' | '2n';
+  duration: NoteDuration;
   time?: number;
   velocity?: number;
 }
@@ -83,7 +84,7 @@ async function loadInstruments(): Promise<void> {
 /**
  * Schedule voice release at the exact time note ends.
  */
-function scheduleVoiceRelease(duration: string, time: number): void {
+function scheduleVoiceRelease(duration: NoteDuration, time: number): void {
   const durSec = Tone.Time(duration).toSeconds();
   const releaseTime = time + durSec + 0.04;
 
@@ -109,7 +110,7 @@ function scheduleVoiceRelease(duration: string, time: number): void {
  */
 export function triggerWithCap(
   note: string,
-  duration: string,
+  duration: NoteDuration,
   time?: number,
   velocity?: number,
   synthType?: string

--- a/src/engine/melodyGenerator.ts
+++ b/src/engine/melodyGenerator.ts
@@ -1,10 +1,15 @@
 // ========================================
+// IMPORTS
+// ========================================
+import type { NoteDuration } from '../types/Robot';
+
+// ========================================
 // TYPES
 // ========================================
 export interface RobotMelodyEvent {
   id: string;
   startStep: number; // 1..16 (8th-note position in 2-measure loop)
-  length: '8n' | '4n' | '2n'; // Note duration
+  length: NoteDuration; // Note duration
   noteIndex: number; // 0..7 (maps into availableNotes palette)
 }
 
@@ -22,8 +27,8 @@ const MAX_EVENTS = 12;
 const DEFAULT_SYNCOPATION_BIAS = 0.4;
 
 const NOTE_INDEX_WEIGHTS = [0.35, 0.2, 0.15, 0.1, 0.07, 0.06, 0.04, 0.03];
-const LENGTH_WEIGHTS = [0.6, 0.3, 0.1];
-const LENGTHS: Array<'8n' | '4n' | '2n'> = ['8n', '4n', '2n'];
+const LENGTH_WEIGHTS = [0.6, 0.3, 0.1, 0.0];
+const LENGTHS: NoteDuration[] = ['16n', '8n', '4n', '2n'];
 
 const ON_BEAT_STEPS = [1, 3, 5, 7, 9, 11, 13, 15];
 const OFF_BEAT_STEPS = [2, 4, 6, 8, 10, 12, 14, 16];
@@ -97,9 +102,9 @@ export function pickWeightedIndex(rand: () => number = Math.random): number {
 
 /**
  * Picks a note length with bias toward shorter durations.
- * '8n' 60%, '4n' 30%, '2n' 10%
+ * '16n' 0%, '8n' 60%, '4n' 30%, '2n' 10%
  */
-export function pickLength(rand: () => number = Math.random): '8n' | '4n' | '2n' {
+export function pickLength(rand: () => number = Math.random): NoteDuration {
   const r = rand();
   let acc = 0;
 

--- a/src/systems/interactionSystem.ts
+++ b/src/systems/interactionSystem.ts
@@ -3,6 +3,8 @@
 // ========================================
 import gsap from 'gsap';
 
+import { getAvailableNotes } from '../engine/harmonySystem';
+import { AudioEngine } from '../engine/AudioEngine';
 import { useOceanStore } from '../stores/oceanStore';
 import { RobotState } from '../types/Robot';
 import { DEV_TUNING } from '../constants';
@@ -14,19 +16,102 @@ import { getRef } from '../utils/refs';
 // CONSTANTS
 // ========================================
 const INTERACTION_COOLDOWN_MS = 5000; // 5 seconds between interactions
-const INTERACTION_DURATION = 1.0; // 1 second interaction before returning to idle
+const INTERACTION_DURATION = 0.5; // 0.5 second interaction before returning to idle
+const FLURRY_NOTE_COUNT = 4; // Number of notes from each robot's melody
 
 // ========================================
 // INTERACTION LOGIC
 // ========================================
 
 /**
+ * Play rapid notes from both robots' melodies to create an "interaction flurry" sound.
+ * Picks random notes from each robot and schedules them with 32nd note spacing.
+ */
+function playInteractionFlurry(robotAId: string, robotBId: string): void {
+  const store = useOceanStore.getState();
+  const robotA = store.getRobotById(robotAId);
+  const robotB = store.getRobotById(robotBId);
+  const notes = getAvailableNotes();
+
+  if (!robotA || !robotB || robotA.melody.length === 0 || robotB.melody.length === 0) {
+    return;
+  }
+
+  const now = gsap.ticker.time;
+  const noteSpacing = 0.125; // 32nd note in seconds at 120 BPM
+
+  // Play flurry from Robot A (starting at now)
+  for (let i = 0; i < FLURRY_NOTE_COUNT && i < robotA.melody.length; i++) {
+    const randomEventA = robotA.melody[Math.floor(Math.random() * robotA.melody.length)];
+    const noteA = notes[randomEventA.noteIndex];
+
+    if (noteA) {
+      AudioEngine.scheduleNote({
+        robotId: robotAId,
+        note: noteA,
+        duration: '16n',
+        time: now + i * noteSpacing,
+        velocity: 0.7,
+      });
+    }
+  }
+
+  // Play flurry from Robot B (slightly staggered overlap)
+  for (let i = 0; i < FLURRY_NOTE_COUNT && i < robotB.melody.length; i++) {
+    const randomEventB = robotB.melody[Math.floor(Math.random() * robotB.melody.length)];
+    const noteB = notes[randomEventB.noteIndex];
+
+    if (noteB) {
+      AudioEngine.scheduleNote({
+        robotId: robotBId,
+        note: noteB,
+        duration: '16n',
+        time: now + noteSpacing * 0.5 + i * noteSpacing,
+        velocity: 0.7,
+      });
+    }
+  }
+
+  if (DEV_TUNING) {
+    console.log(
+      `[Interaction] Flurry: ${FLURRY_NOTE_COUNT} notes from each robot (16th notes)`
+    );
+  }
+}
+
+/**
+ * Trigger visual effects for robot interaction (scale pulse + rotation).
+ */
+function playInteractionAnimation(robotAId: string, robotBId: string): void {
+  const refA = getRef(`robot-${robotAId}`);
+  const refB = getRef(`robot-${robotBId}`);
+
+  // Scale pulse: grow to 1.25x and back
+  if (refA) {
+    gsap.to(refA, {
+      scale: 1.25,
+      duration: 0.15,
+      yoyo: true,
+      repeat: 1,
+      ease: 'back.out',
+    });
+  }
+
+  if (refB) {
+    gsap.to(refB, {
+      scale: 1.25,
+      duration: 0.15,
+      yoyo: true,
+      repeat: 1,
+      ease: 'back.out',
+    });
+  }
+}
+
+/**
  * Trigger interaction between two robots.
- * Sets both robots to interacting state and applies cooldown.
+ * Sets both robots to interacting state, plays note flurry, and triggers visual effects.
  * After brief interaction, returns robots to idle state.
- * 
- * NOTE: This is a stub implementation. Full interaction logic
- * (audio events, animations, etc.) will be implemented in M4.2+
  */
 export function triggerInteraction(robotAId: string, robotBId: string): void {
   const store = useOceanStore.getState();
@@ -35,6 +120,10 @@ export function triggerInteraction(robotAId: string, robotBId: string): void {
   // Kill any active swim timelines (stop current movement)
   killTimeline(`swim-${robotAId}`);
   killTimeline(`swim-${robotBId}`);
+
+  // Play interaction effects (audio + visual)
+  playInteractionFlurry(robotAId, robotBId);
+  playInteractionAnimation(robotAId, robotBId);
 
   // Update both robots to interacting state
   store.updateRobot(robotAId, {
@@ -49,7 +138,7 @@ export function triggerInteraction(robotAId: string, robotBId: string): void {
 
   if (DEV_TUNING) {
     console.log(
-      `[Interaction] Robots ${robotAId} and ${robotBId} interacting (cooldown: ${INTERACTION_COOLDOWN_MS}ms)`
+      `[Interaction] Robots ${robotAId} and ${robotBId} interacting (cooldown: ${INTERACTION_COOLDOWN_MS}ms, duration: ${INTERACTION_DURATION}s)`
     );
   }
 
@@ -87,9 +176,4 @@ export function triggerInteraction(robotAId: string, robotBId: string): void {
       handleRobotIdle(robotBId);
     }
   });
-
-  // TODO (M4.2+): Implement full interaction behavior:
-  // - Play interaction audio event
-  // - Trigger interaction animation
-  // - Handle melody exchange/modification
 }

--- a/src/types/Robot.ts
+++ b/src/types/Robot.ts
@@ -1,6 +1,12 @@
 import type { Vec2 } from './Vec2';
 
 /**
+ * Note duration values for Tone.js scheduling
+ * Standard musical note lengths: 32nd, 16th, 8th, quarter, half
+ */
+export type NoteDuration = '32n' | '16n' | '8n' | '4n' | '2n';
+
+/**
  * Robot state machine states
  */
 export enum RobotState {
@@ -47,7 +53,7 @@ export interface AudioAttributes {
 export interface MelodyEvent {
   id: string;                           // Unique identifier (UUID)
   startStep: number;                    // 1-16 (8th-note grid position)
-  length: '8n' | '4n' | '2n';          // Note duration
+  length: NoteDuration;                 // Note duration
   noteIndex: number;                    // 0-7 (index into available harmony palette)
 }
 


### PR DESCRIPTION
Description
Implement robot collision interaction effects: when two robots collide, play a rapid note flurry (4 notes per robot) and trigger a visual scale pulse. Robots pause for 0.5s with a 5s cooldown before interacting again. Introduces unified [NoteDuration](vscode-file://vscode-app/c:/Users/crawf/AppData/Local/Programs/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) type across audio systems.

Type of Change
 New feature
 Bug fix
Testing
 Tested locally
 TypeScript compiles
 No architectural violations
Checklist
 Code follows style guidelines
 Self-review completed
Related Issues
Closes #33