### PR TITLE
feat(interactions): implement measure-based interaction cooldown

### DIFF
--- a/src/systems/collisionSystem.test.ts
+++ b/src/systems/collisionSystem.test.ts
@@ -1,11 +1,16 @@
 // ========================================
 // IMPORTS
 // ========================================
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import { calculateDistanceSquared, canInteract } from './collisionSystem';
 import { RobotState } from '../types/Robot';
 import type { Robot } from '../types/Robot';
+
+// Mock BeatClock
+vi.mock('../engine/beatClock', () => ({
+  getCurrentMeasure: vi.fn(() => 100),
+}));
 
 // ========================================
 // TESTS
@@ -104,34 +109,41 @@ describe('CollisionSystem', () => {
       expect(canInteract(robot)).toBe(false);
     });
 
-    it('returns false when robot is on cooldown', () => {
-      const futureTime = Date.now() + 5000; // 5 seconds from now
+    it('returns false when robot is on cooldown (less than 8 measures elapsed)', () => {
       const robot: Robot = {
         ...baseRobot,
         state: RobotState.Idle,
-        interactionCooldown: futureTime,
+        lastInteractionMeasure: 95, // 5 measures ago (100 - 95 = 5 < 8)
       };
 
       expect(canInteract(robot)).toBe(false);
     });
 
-    it('returns true when cooldown has expired', () => {
-      const pastTime = Date.now() - 1000; // 1 second ago
+    it('returns true when cooldown has expired (8+ measures elapsed)', () => {
       const robot: Robot = {
         ...baseRobot,
         state: RobotState.Idle,
-        interactionCooldown: pastTime,
+        lastInteractionMeasure: 92, // 8 measures ago (100 - 92 = 8 >= 8)
+      };
+
+      expect(canInteract(robot)).toBe(true);
+    });
+
+    it('returns true when cooldown has completely expired (many measures elapsed)', () => {
+      const robot: Robot = {
+        ...baseRobot,
+        state: RobotState.Idle,
+        lastInteractionMeasure: 50, // 50 measures ago
       };
 
       expect(canInteract(robot)).toBe(true);
     });
 
     it('returns false for moving robot on cooldown', () => {
-      const futureTime = Date.now() + 5000;
       const robot: Robot = {
         ...baseRobot,
         state: RobotState.Moving,
-        interactionCooldown: futureTime,
+        lastInteractionMeasure: 98, // 2 measures ago (100 - 98 = 2 < 8)
       };
 
       expect(canInteract(robot)).toBe(false);

--- a/src/systems/collisionSystem.ts
+++ b/src/systems/collisionSystem.ts
@@ -9,6 +9,7 @@ import type { Vec2 } from '../types/Vec2';
 import { useOceanStore } from '../stores/oceanStore';
 import { triggerInteraction } from './interactionSystem';
 import { getRef } from '../utils/refs';
+import { getCurrentMeasure } from '../engine/beatClock';
 
 // ========================================
 // CONSTANTS
@@ -37,15 +38,17 @@ export function calculateDistanceSquared(a: Vec2, b: Vec2): number {
 
 /**
  * Check if a robot can interact (correct state and not on cooldown).
+ * Cooldown is measure-based: robots must wait 8 measures between interactions.
  */
 export function canInteract(robot: Robot): boolean {
   // Must be in idle or moving state
   const validState =
     robot.state === RobotState.Idle || robot.state === RobotState.Moving;
 
-  // Must not be on cooldown
-  const notOnCooldown =
-    !robot.interactionCooldown || Date.now() >= robot.interactionCooldown;
+  // Check measure-based cooldown (8 measures = cooldown duration)
+  const notOnCooldown = !robot.lastInteractionMeasure
+    ? true
+    : getCurrentMeasure() - robot.lastInteractionMeasure >= 8;
 
   return validState && notOnCooldown;
 }

--- a/src/systems/interactionSystem.ts
+++ b/src/systems/interactionSystem.ts
@@ -5,6 +5,7 @@ import gsap from 'gsap';
 
 import { getAvailableNotes } from '../engine/harmonySystem';
 import { AudioEngine } from '../engine/AudioEngine';
+import { getCurrentMeasure } from '../engine/beatClock';
 import { useOceanStore } from '../stores/oceanStore';
 import { RobotState } from '../types/Robot';
 import { DEV_TUNING } from '../constants';
@@ -15,7 +16,7 @@ import { getRef } from '../utils/refs';
 // ========================================
 // CONSTANTS
 // ========================================
-const INTERACTION_COOLDOWN_MS = 5000; // 5 seconds between interactions
+const INTERACTION_COOLDOWN_MEASURES = 8; // 8 measures between interactions
 const INTERACTION_DURATION = 0.5; // 0.5 second interaction before returning to idle
 const FLURRY_NOTE_COUNT = 4; // Number of notes from each robot's melody
 
@@ -117,7 +118,7 @@ function playInteractionAnimation(robotAId: string, robotBId: string): void {
  */
 export function triggerInteraction(robotAId: string, robotBId: string): void {
   const store = useOceanStore.getState();
-  const cooldownExpiry = Date.now() + INTERACTION_COOLDOWN_MS;
+  const currentMeasure = getCurrentMeasure();
 
   // Kill any active swim timelines (stop current movement)
   killTimeline(`swim-${robotAId}`);
@@ -127,20 +128,20 @@ export function triggerInteraction(robotAId: string, robotBId: string): void {
   playInteractionFlurry(robotAId, robotBId);
   playInteractionAnimation(robotAId, robotBId);
 
-  // Update both robots to interacting state
+  // Update both robots to interacting state with measure-based cooldown
   store.updateRobot(robotAId, {
     state: RobotState.Interacting,
-    interactionCooldown: cooldownExpiry,
+    lastInteractionMeasure: currentMeasure,
   });
 
   store.updateRobot(robotBId, {
     state: RobotState.Interacting,
-    interactionCooldown: cooldownExpiry,
+    lastInteractionMeasure: currentMeasure,
   });
 
   if (DEV_TUNING) {
     console.log(
-      `[Interaction] Robots ${robotAId} and ${robotBId} interacting (cooldown: ${INTERACTION_COOLDOWN_MS}ms, duration: ${INTERACTION_DURATION}s)`
+      `[Interaction] Robots ${robotAId} and ${robotBId} interacting (measure ${currentMeasure}, cooldown: ${INTERACTION_COOLDOWN_MEASURES} measures)`
     );
   }
 

--- a/src/types/Robot.ts
+++ b/src/types/Robot.ts
@@ -69,7 +69,7 @@ export interface Robot {
   destination: Vec2 | null;
   melody: MelodyEvent[];
   audioAttributes: AudioAttributes;
-  interactionCooldown?: number; // Timestamp (ms) when interaction cooldown expires
+  lastInteractionMeasure?: number; // Measure number when robot last interacted
   // Note: Visual appearance (shape, colors, scale, detail level) is derived
   // from audioAttributes and NOT stored in state - calculated at render time
 }


### PR DESCRIPTION
## Description
Replace time-based interaction cooldown (milliseconds) with measure-based cooldown (8 measures). Robots can now interact again after 8 musical measures pass, synchronized with the BeatClock instead of wall-clock time.

## Type of Change
- [x] New feature

## Testing
- [x] Tested locally
- [x] TypeScript compiles
- [x] No architectural violations

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed

## Related Issues
Closes #36