### PR TITLE
feat(debug): add interaction status overlay with real-time metrics

### DIFF
--- a/src/components/OceanScene.tsx
+++ b/src/components/OceanScene.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import './OceanScene.css';
 import { Robot } from './robot/Robot';
+import { InteractionStatus } from './debug/InteractionStatus';
 import { useOceanStore } from '../stores/oceanStore';
 import { spawnRobot } from '../systems/spawnSystem';
 import { handleRobotIdle } from '../systems/idleSystem';
@@ -59,21 +60,24 @@ export function OceanScene({
   }, []);
 
   return (
-    <svg
-      viewBox={`0 0 ${width} ${height}`}
-      className="ocean-scene"
-      width={width}
-      height={height}
-    >
-      <rect fill={BACKGROUND_COLOR} width={width} height={height} />
-      <g id="background-layer" />
-      <g id="robot-layer">
-        {robots.map((robot) => (
-          <Robot key={robot.id} robot={robot} />
-        ))}
-      </g>
-      <g id="foreground-layer" />
-      <g id="ui-layer" />
-    </svg>
+    <>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="ocean-scene"
+        width={width}
+        height={height}
+      >
+        <rect fill={BACKGROUND_COLOR} width={width} height={height} />
+        <g id="background-layer" />
+        <g id="robot-layer">
+          {robots.map((robot) => (
+            <Robot key={robot.id} robot={robot} />
+          ))}
+        </g>
+        <g id="foreground-layer" />
+        <g id="ui-layer" />
+      </svg>
+      <InteractionStatus />
+    </>
   );
 }

--- a/src/components/debug/InteractionStatus.tsx
+++ b/src/components/debug/InteractionStatus.tsx
@@ -1,0 +1,94 @@
+// ========================================
+// IMPORTS
+// ========================================
+import { useEffect, useState } from 'react';
+import gsap from 'gsap';
+
+import { DEV_TUNING } from '../../constants';
+import { useOceanStore } from '../../stores/oceanStore';
+import { getCollisionChecksPerSecond } from '../../systems/collisionSystem';
+import { getCurrentMeasure } from '../../engine/beatClock';
+import type { Robot } from '../../types/Robot';
+
+// ========================================
+// TYPES
+// ========================================
+interface InteractionStats {
+  totalInteractions: number;
+  cooldownCount: number;
+  collisionChecksPerSecond: number;
+  currentMeasure: number;
+}
+
+// ========================================
+// COMPONENT
+// ========================================
+export function InteractionStatus() {
+  const robots = useOceanStore((s) => s.robots);
+  const totalInteractions = useOceanStore((s) => s.totalInteractions);
+  const [stats, setStats] = useState<InteractionStats>({
+    totalInteractions: 0,
+    cooldownCount: 0,
+    collisionChecksPerSecond: 0,
+    currentMeasure: 0,
+  });
+
+  useEffect(() => {
+    if (!DEV_TUNING) return;
+
+    let tickerCallback: (() => void) | null = null;
+
+    tickerCallback = () => {
+      // Count robots currently on cooldown (have lastInteractionMeasure and within cooldown window)
+      const currentMeasure = getCurrentMeasure();
+      const cooldownCount = robots.filter((robot: Robot) => {
+        if (!robot.lastInteractionMeasure) return false;
+        const measuresSinceInteraction = currentMeasure - robot.lastInteractionMeasure;
+        return measuresSinceInteraction < 8; // 8 measure cooldown
+      }).length;
+
+      setStats({
+        totalInteractions,
+        cooldownCount,
+        collisionChecksPerSecond: getCollisionChecksPerSecond(),
+        currentMeasure: Math.floor(currentMeasure),
+      });
+    };
+
+    gsap.ticker.add(tickerCallback);
+
+    return () => {
+      if (tickerCallback) {
+        gsap.ticker.remove(tickerCallback);
+      }
+    };
+  }, [robots, totalInteractions]);
+
+  if (!DEV_TUNING) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '10px',
+        right: '10px',
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        color: '#00ff00',
+        fontFamily: 'monospace',
+        fontSize: '12px',
+        padding: '8px 12px',
+        borderRadius: '4px',
+        zIndex: 9999,
+        pointerEvents: 'none',
+        lineHeight: '1.4',
+      }}
+    >
+      <div>Interactions: {stats.totalInteractions}</div>
+      <div>
+        Cooldowns: {stats.cooldownCount}/{robots.length}
+      </div>
+      <div>Checks/sec: {stats.collisionChecksPerSecond}</div>
+      <div>Measure: {stats.currentMeasure}</div>
+    </div>
+  );
+}

--- a/src/stores/oceanStore.ts
+++ b/src/stores/oceanStore.ts
@@ -15,6 +15,7 @@ import { DEV_TUNING } from '../constants';
 interface OceanStore {
   robots: Robot[];
   selectedRobotId: string | null;
+  totalInteractions: number;
   settings: {
     bpm: number;
     maxRobots: number;
@@ -24,6 +25,7 @@ interface OceanStore {
   updateRobot: (id: string, updates: Partial<Robot>) => void;
   getRobotById: (id: string) => Robot | undefined;
   selectRobot: (id: string | null) => void;
+  incrementInteractions: () => void;
 }
 
 // ========================================
@@ -40,6 +42,7 @@ const INITIAL_SETTINGS = {
 export const useOceanStore = create<OceanStore>((_set, get) => ({
   robots: [],
   selectedRobotId: null,
+  totalInteractions: 0,
   settings: { ...INITIAL_SETTINGS },
 
   addRobot: (robot) => {
@@ -79,6 +82,12 @@ export const useOceanStore = create<OceanStore>((_set, get) => ({
 
   selectRobot: (id) => {
     _set({ selectedRobotId: id });
+  },
+
+  incrementInteractions: () => {
+    _set((state) => ({
+      totalInteractions: state.totalInteractions + 1,
+    }));
   },
 }));
 

--- a/src/systems/collisionSystem.ts
+++ b/src/systems/collisionSystem.ts
@@ -21,6 +21,8 @@ const INTERACTION_DISTANCE_SQUARED = INTERACTION_DISTANCE * INTERACTION_DISTANCE
 // MODULE STATE
 // ========================================
 let tickerCallback: (() => void) | null = null;
+let collisionChecksPerSecond = 0;
+let frameCount = 0;
 
 // ========================================
 // HELPER FUNCTIONS
@@ -72,6 +74,13 @@ function getVisualPosition(robot: Robot): Vec2 {
   return { x, y };
 }
 
+/**
+ * Get collision checks per second (for debug display).
+ */
+export function getCollisionChecksPerSecond(): number {
+  return collisionChecksPerSecond;
+}
+
 // ========================================
 // COLLISION DETECTION
 // ========================================
@@ -86,8 +95,22 @@ export function startCollisionDetection(): void {
     return;
   }
 
+  collisionChecksPerSecond = 0;
+  frameCount = 0;
+  let lastTime = gsap.ticker.time;
+
   tickerCallback = () => {
     const robots = useOceanStore.getState().robots;
+    const checkCount = (robots.length * (robots.length - 1)) / 2;
+
+    // Update collision checks per second metric
+    frameCount += checkCount;
+    const currentTime = gsap.ticker.time;
+    if (currentTime - lastTime >= 1) {
+      collisionChecksPerSecond = frameCount;
+      frameCount = 0;
+      lastTime = currentTime;
+    }
 
     // Check all unique pairs
     for (let i = 0; i < robots.length; i++) {

--- a/src/systems/interactionSystem.ts
+++ b/src/systems/interactionSystem.ts
@@ -128,6 +128,9 @@ export function triggerInteraction(robotAId: string, robotBId: string): void {
   playInteractionFlurry(robotAId, robotBId);
   playInteractionAnimation(robotAId, robotBId);
 
+  // Increment total interaction counter for debug display
+  store.incrementInteractions();
+
   // Update both robots to interacting state with measure-based cooldown
   store.updateRobot(robotAId, {
     state: RobotState.Interacting,


### PR DESCRIPTION
## Description
Add debug overlay showing real-time interaction statistics: total interactions, robots on cooldown, collision checks per second, and current measure. Gated behind `DEV_TUNING` flag for development-only visibility.

## Type of Change
- [x] New feature

## Testing
- [x] Tested locally
- [x] TypeScript compiles
- [x] No architectural violations

## Implementation Details
- Created `InteractionStatus` component with fixed bottom-right positioning
- Added `totalInteractions` counter to oceanStore with `incrementInteractions()` action
- Collision checks per second tracked via `getCollisionChecksPerSecond()` export
- Cooldown detection uses measure-based logic (8 measure window from `lastInteractionMeasure`)
- Real-time updates via GSAP ticker (no `setInterval`)

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed

## Related Issues
Closes #37