### PR TITLE
refactor(components): remove collision and interaction systems

### DIFF
--- a/src/components/OceanScene.tsx
+++ b/src/components/OceanScene.tsx
@@ -2,13 +2,8 @@ import { useEffect, useMemo } from 'react';
 
 import './OceanScene.css';
 import { Robot } from './robot/Robot';
-import { InteractionStatus } from './debug/InteractionStatus';
 import { useOceanStore } from '../stores/oceanStore';
 import { spawnRobot, startSpawnScheduler, stopSpawnScheduler } from '../systems/spawnSystem';
-import {
-  startCollisionDetection,
-  stopCollisionDetection,
-} from '../systems/collisionSystem';
 import { Factory } from './actors/Factory';
 import { placeFactories, getRowConfig } from '../systems/factoryPlacementSystem';
 import { ActorType } from '../types/Actor';
@@ -88,14 +83,12 @@ export function OceanScene({
       }
     });
 
-    // Start periodic robot spawning and collision detection
+    // Start periodic robot spawning
     startSpawnScheduler();
-    startCollisionDetection();
 
     // Cleanup on unmount
     return () => {
       stopSpawnScheduler();
-      stopCollisionDetection();
     };
   }, []);
 
@@ -172,7 +165,6 @@ export function OceanScene({
         </g>
         <g id="ui-layer" />
       </svg>
-      <InteractionStatus />
     </>
   );
 }

--- a/src/types/Robot.ts
+++ b/src/types/Robot.ts
@@ -12,7 +12,6 @@ export type NoteDuration = '32n' | '16n' | '8n' | '4n' | '2n';
 export enum RobotState {
   Idle = 'idle',
   Moving = 'moving',
-  Interacting = 'interacting',
   Selected = 'selected',
   Leaving = 'leaving',
 }
@@ -70,7 +69,6 @@ export interface Robot {
   melody: MelodyEvent[];
   audioAttributes: AudioAttributes;
   layer?: 'background' | 'foreground'; // SVG rendering layer (default: foreground)
-  lastInteractionMeasure?: number; // Measure number when robot last interacted
   // Note: Visual appearance (shape, colors, scale, detail level) is derived
   // from audioAttributes and NOT stored in state - calculated at render time
 }


### PR DESCRIPTION
Clean up M4 remnants by deleting collision detection and robot interaction logic. Collision scheduler calls are removed from OceanScene, and the Robot type no longer tracks interaction state.

- Deleted imports and lifecycle hooks for collision/interaction systems in OceanScene
- Removed Interacting state and lastInteractionMeasure field from Robot interface
- Robots now swim independently; no audio flurries on contact

Closes #133

