### PR TITLE
feat(audio): decouple octave from harmony palette

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -475,7 +475,7 @@ interface Robot {
   destination: Vec2 | null;
   melody: MelodyEvent[];
   audioAttributes: AudioAttributes; // synthType, adsr, pitchRange, filterFreq, reverb
-  octaveOffset: 0 | 1 | 2;         // subtracts octaves at scheduling time
+  octaveRange: [number, number];    // [min, max] octave band; melody events store concrete octaves
   masterVolume: number;             // 0-1, base note velocity
   layer?: 'background' | 'foreground';
   // NO synths, NO timelines, NO DOM refs — those are never stored in state

--- a/docs/HARMONY_SYSTEM.md
+++ b/docs/HARMONY_SYSTEM.md
@@ -11,29 +11,32 @@ Robots don't store literal note strings in their melodies. Instead, they store *
 ```
 Robot Melody: [2, 0, 5, 3, ...]  (note indices, immutable)
                 ↓  ↓  ↓  ↓
-Available Notes: [C4, D4, E4, F4, G4, A4, C5, D5]  (palette, changes every 4 measures)
+Available Notes: ['C', 'G', 'E', 'D', 'B', 'C', 'E', 'G']  (note names, no octave — changes every 4 measures)
                 ↓  ↓  ↓  ↓
-Actual Playback: E4, C4, A4, F4, ...  (automatic mapping)
+Per-event octave: [4,  4,  4,  3,  ...]  (concrete octave stored on each MelodyEvent at spawn)
+                ↓  ↓  ↓  ↓
+Actual Playback: E4, C4, A3, ... (note name + event octave combined at scheduling time)
 ```
 
-When the hour changes, only `availableNotes` swaps—robot melodies remain untouched.
+When the hour changes, only `availableNotes` swaps—robot melodies (indices + octaves) remain untouched.
 
 ## Data Structure
 
 ```typescript
-// Exactly 8 notes per palette
-export type EightNotes = [string, string, string, string, string, string, string, string];
+// Exactly 8 note-name strings (no octave digit) per palette.
+// Octave is determined per-robot at spawn; each MelodyEvent stores a concrete octave.
+export type EighthNotes = [string, string, string, string, string, string, string, string];
 
 // 24-hour cycle mapping (hours 0-23)
-const TIME_PITCHES: Record<number, EightNotes> = {
-  0: ['C4', 'G4', 'E4', 'D4', 'B4', 'C5', 'E5', 'G5'],      // Midnight
-  1: ['C4', 'G4', 'F4', 'D4', 'A4', 'C5', 'F5', 'F5'],      // 1am
-  2: ['D4', 'A4', 'F4', 'D4', 'A4', 'C5', 'F5', 'D5'],      // 2am
+const TIME_PITCHES: Record<number, EighthNotes> = {
+  0:  ['C',  'G',  'E',  'D',  'B',  'C',  'E',  'G' ],  // Midnight
+  1:  ['C',  'G',  'F',  'D',  'A',  'C',  'F',  'F' ],  // 1am
+  2:  ['D',  'A',  'F',  'D',  'A',  'C',  'F',  'D' ],  // 2am
   // ... (24 total palettes)
-  6: ['Bb4', 'D4', 'C4', 'G4', 'F4', 'C5', 'Bb5', 'F5'],    // Dawn
-  12: ['E4', 'B4', 'G#4', 'F#4', 'C#5', 'E5', 'B5', 'G#5'], // Noon
-  18: ['Ab4', 'Eb4', 'Bb4', 'F4', 'Db5', 'Ab5', 'Eb5', 'Bb5'], // Dusk
-  23: ['C4', 'G4', 'E4', 'D4', 'B4', 'C5', 'E5', 'G5'],     // Late night
+  6:  ['Bb', 'D',  'C',  'G',  'F',  'C',  'Bb', 'F' ],  // Dawn
+  12: ['C',  'G',  'E',  'D',  'B',  'C',  'E',  'G' ],  // Noon
+  18: ['Bb', 'D',  'C',  'G',  'F',  'C',  'Bb', 'F' ],  // Dusk
+  23: ['E',  'C',  'G#', 'D',  'Bb', 'E',  'G#', 'B' ],  // Late night
 };
 ```
 
@@ -93,13 +96,14 @@ BeatClock.scheduleRepeat('8n', (time) => {
   const currentStep = (stepCounter % 16) + 1;
   const eventsAtStep = melodyRegistry.get(currentStep) || [];
   
-  eventsAtStep.forEach(event => {
-    const notes = getAvailableNotes();  // Get current palette
-    const note = notes[event.noteIndex]; // Map index → pitch
+  eventsAtStep.forEach(({ robotId, event }) => {
+    const notes = getAvailableNotes();         // note names, e.g. ['C', 'G', ...]
+    const noteName = notes[event.noteIndex];   // e.g. 'C'
+    const note = `${noteName}${event.octave}`; // e.g. 'C4' — octave baked in at spawn
     
     AudioEngine.scheduleNote({
-      robotId: event.robotId,
-      note,  // Automatically uses new harmony
+      robotId,
+      note,  // Automatically uses new harmony + robot's spawn-time octave
       duration: event.length,
       time: time + MIN_LEAD,
     });
@@ -140,9 +144,9 @@ const derivedHour = Math.floor((currentMeasure % 96) / 4);  // 0..23
 When creating custom `TIME_PITCHES`:
 
 1. **Use 8 notes exactly** (EightNotes type enforces this)
-2. **Range:** Stay within 2-3 octaves (e.g., C3-C5)
-3. **Avoid extreme leaps:** Adjacent indices should be reasonably close
-4. **Smooth transitions:** Hour N and N+1 should share some notes for continuity
+2. **No octave digits:** All entries are bare note names (`'C'`, `'Bb'`, `'F#'`). Octave is a robot-level attribute, not a palette concern.
+3. **Avoid extreme leaps:** Adjacent indices should be reasonably close in pitch character
+4. **Smooth transitions:** Hour N and N+1 should share some note names for continuity
 5. **Mood mapping:**
    - Midnight-Dawn (0-6): Lower, darker tones
    - Morning (6-12): Brighter, rising pitches
@@ -189,15 +193,18 @@ For unit testing patterns and examples, see [CONTRIBUTION_GUIDE.md](CONTRIBUTION
 
 ## Integration with Melody System
 
-Robots generate melodies at spawn:
+Robots generate melodies at spawn. Each event stores the note index *and* a concrete octave:
 ```typescript
 interface RobotMelodyEvent {
   id: string;
-  startStep: number;     // 1..16
-  length: '8n' | '4n' | '2n';
-  noteIndex: number;     // 0..7 ← Maps into availableNotes
+  startStep: number;                  // 1..16
+  length: '16n' | '8n' | '4n' | '2n';
+  noteIndex: number;                  // 0..7 ← maps into note-name palette
+  octave: number;                     // concrete octave assigned at spawn time
 }
 ```
+
+At scheduling time, `note = availableNotes[event.noteIndex] + event.octave` (e.g. `"C" + 4 = "C4"`). This means a harmony change silently updates the pitch class while the octave register stays as the robot was born with.
 
 At playback:
 ```typescript

--- a/docs/MELODY_SYSTEM.md
+++ b/docs/MELODY_SYSTEM.md
@@ -14,17 +14,21 @@ Melody generation creates unique, procedurally-generated musical patterns for ea
 
 ```typescript
 interface RobotMelodyEvent {
-  id: string;               // Unique identifier (e.g., "mel-abc123")
-  startStep: number;        // 1..16 (8th-note position in 2-measure loop)
-  length: '8n' | '4n' | '2n'; // Note duration
-  noteIndex: number;        // 0..7 (maps into availableNotes palette)
+  id: string;                          // Unique identifier (UUID)
+  startStep: number;                   // 1..16 (8th-note position in 2-measure loop)
+  length: '16n' | '8n' | '4n' | '2n'; // Note duration
+  noteIndex: number;                   // 0..7 (maps into note-name palette)
+  octave: number;                      // Concrete octave assigned at spawn time
 }
 
 interface Robot {
   // ... other fields
-  melody: RobotMelodyEvent[];  // 4-12 events per robot
+  octaveRange: [number, number];   // [min, max] octave band for this robot
+  melody: RobotMelodyEvent[];      // 4-12 events per robot
 }
 ```
+
+`noteIndex` maps into the **note-name** palette (e.g. `'C'`, `'Bb'`). `octave` is baked in at spawn and stays stable across harmony changes. The full pitch is composed at scheduling time: `noteName + octave`.
 
 ## Generation Algorithm
 
@@ -32,15 +36,33 @@ interface Robot {
 
 ```typescript
 export function generateMelodyForRobot(opts?: {
-  events?: number;           // Number of notes (default: 4-12)
-  rand?: () => number;       // RNG for testing (default: Math.random)
-  syncopationBias?: number;  // 0-1, off-beat preference (default: 0.4)
+  events?: number;                  // Number of notes (default: 4-12)
+  rand?: () => number;              // RNG for testing (default: Math.random)
+  syncopationBias?: number;         // 0-1, off-beat preference (default: 0.4)
+  octaveRange?: [number, number];   // [min, max] octave band for this robot
 }): RobotMelodyEvent[] {
   const eventsCount = opts?.events ?? (4 + Math.floor(Math.random() * 9));
+  const [octMin, octMax] = opts?.octaveRange ?? [3, 4];
+
+  // Seed a random starting octave within the robot's range
+  let currentOctave = octMin + Math.floor(Math.random() * (octMax - octMin + 1));
+
   const melody: RobotMelodyEvent[] = [];
   const usedSlots = new Set<number>();
   
   for (let i = 0; i < eventsCount; i++) {
+    // 15% chance to jump more than one octave (when range allows)
+    if (i > 0 && Math.random() < 0.15) {
+      const jumpCandidates = [];
+      for (let o = octMin; o <= octMax; o++) {
+        if (Math.abs(o - currentOctave) > 1) jumpCandidates.push(o);
+      }
+      if (jumpCandidates.length > 0) {
+        currentOctave = jumpCandidates[Math.floor(Math.random() * jumpCandidates.length)];
+      }
+      // Span too narrow to jump — stay on current octave
+    }
+
     // 1. Pick step position
     const useOffBeat = Math.random() < (opts?.syncopationBias ?? 0.4);
     const candidateSteps = useOffBeat 
@@ -68,6 +90,7 @@ export function generateMelodyForRobot(opts?: {
       startStep,
       length,
       noteIndex,
+      octave: currentOctave,  // concrete octave for this note
     });
   }
   
@@ -107,14 +130,16 @@ export function pickWeightedIndex(rand = Math.random): number {
 ## Duration Selection
 
 ```typescript
-function pickLength(rand = Math.random): '8n' | '4n' | '2n' {
-  const weights = [0.6, 0.3, 0.1];  // Bias toward shorter notes
+function pickLength(rand = Math.random): NoteDuration {
+  // Order: 8n, 4n, 2n, 16n
+  const weights = [0.5, 0.25, 0.15, 0.1];
+  const lengths: NoteDuration[] = ['8n', '4n', '2n', '16n'];
   const r = rand();
   let acc = 0;
   
   for (let i = 0; i < weights.length; i++) {
     acc += weights[i];
-    if (r <= acc) return ['8n', '4n', '2n'][i];
+    if (r <= acc) return lengths[i];
   }
   
   return '8n';
@@ -122,9 +147,10 @@ function pickLength(rand = Math.random): '8n' | '4n' | '2n' {
 ```
 
 **Distribution:**
-- `8n` (eighth note): **60%** (shortest, most rhythmic)
-- `4n` (quarter note): **30%** (medium)
-- `2n` (half note): **10%** (longest, sustained)
+- `8n` (eighth note): **50%**
+- `4n` (quarter note): **25%**
+- `2n` (half note): **15%**
+- `16n` (sixteenth note): **10%**
 
 ## Syncopation Control
 
@@ -147,17 +173,20 @@ const useOffBeat = Math.random() < syncopationBias;
 ```typescript
 // In robot spawner
 function spawnRobot(): Robot {
-  const melody = generateMelodyForRobot({
-    events: 6,               // This robot gets 6 notes
-    syncopationBias: 0.5,    // Moderately syncopated
-  });
-  
+  const audioAttributes = generateAudioAttributes();
+  const octaveRange = pickOctaveRange(audioAttributes.pitchRange);
+  // low pitch bucket → [2,3], mid → [3,4], high → [4,5]
+
+  const melody = generateMelodyForRobot({ octaveRange });
+  // Each event has .octave set; stays stable across harmony changes
+
   return {
     id: crypto.randomUUID(),
-    position: { x: 100, y: 200, z: 2 },
     state: 'idle',
+    audioAttributes,
+    octaveRange,
     melody,  // Immutable from this point forward
-    // ... other fields
+    // ...
   };
 }
 ```
@@ -194,7 +223,8 @@ BeatClock.scheduleRepeat('8n', (time) => {
   const notes = getAvailableNotes();
   
   events.forEach(({ robotId, event }) => {
-    const note = notes[event.noteIndex];  // Map index → pitch
+    const noteName = notes[event.noteIndex];    // e.g. 'C' (from note-name palette)
+    const note = `${noteName}${event.octave}`; // e.g. 'C4'
     
     scheduleNote({
       robotId,

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -223,6 +223,15 @@ export function triggerWithCap(params: NoteParams): boolean {
       }
     }
 
+    // Validate note string before touching the synth — an invalid note can start
+    // an oscillator attack before throwing, leaving voices permanently open.
+    const NOTE_RE = /^[A-Ga-g][b#]{0,2}\d+$/;
+    if (!NOTE_RE.test(note)) {
+      activeVoices = Math.max(0, activeVoices - 1);
+      console.warn(`[AudioEngine] Invalid note string "${note}", skipping`);
+      return false;
+    }
+
     synth.triggerAttackRelease(note, duration, scheduleTime, velocity ?? 0.8);
     scheduleVoiceRelease(duration, scheduleTime);
 
@@ -248,14 +257,18 @@ function startMelodyPlayback(): void {
     const notes = getAvailableNotes();
 
     events.forEach(({ robotId, event }) => {
-      const note = notes[event.noteIndex]; // Map index → pitch
+      const noteName = notes[event.noteIndex]; // note name without octave, e.g. "C"
 
-      if (!note) {
+      if (!noteName) {
         console.warn(
           `[AudioEngine] Invalid note index ${event.noteIndex} for robot ${robotId}`
         );
         return;
       }
+
+      // Fallback octave of 4 handles stale events that pre-date the octaveRange change.
+      const octave = event.octave ?? 4;
+      const note = `${noteName}${octave}`; // combine with per-event octave, e.g. "C4"
 
       AudioEngine.scheduleNote({
         robotId,

--- a/src/engine/harmonySystem.test.ts
+++ b/src/engine/harmonySystem.test.ts
@@ -61,7 +61,7 @@ describe('harmonySystem', () => {
     expect(mockTransport.scheduleRepeat).toHaveBeenCalledTimes(1);
     currentHour = 5;
     callbacks[0]?.();
-    expect(getAvailableNotes()[0]).toBe('A4');
+    expect(getAvailableNotes()[0]).toBe('A');
   });
 
   it('stops harmony cycle and clears scheduled event', () => {

--- a/src/engine/harmonySystem.ts
+++ b/src/engine/harmonySystem.ts
@@ -17,7 +17,8 @@ let transportInstance: TransportLike | null = null;
 // ========================================
 // TYPES
 // ========================================
-// Require exactly 8 note strings per hour-equivalent (derived from measure position for palette lookup, not stored).
+// Exactly 8 note-name strings (no octave digit) per hour-equivalent.
+// Octave is determined per-robot at spawn time; melody events store note index + octave separately.
 // Hour is calculated as Math.floor((currentMeasure % 96) / 4) where 96 measures = 1 full day cycle.
 export type EighthNotes = [string, string, string, string, string, string, string, string];
 
@@ -25,30 +26,30 @@ export type EighthNotes = [string, string, string, string, string, string, strin
 // CONSTANTS
 // ========================================
 const TIME_PITCHES: Record<number, EighthNotes> = {
-  0: ['C4', 'G4', 'E4', 'D4', 'B4', 'C5', 'E5', 'G5'],
-  1: ['C4', 'G4', 'F4', 'D4', 'A4', 'C5', 'F5', 'F5'],
-  2: ['D4', 'A4', 'F4', 'D4', 'A4', 'C5', 'F5', 'D5'],
-  3: ['F4', 'G4', 'B4', 'D4', 'G4', 'D5', 'G5', 'G5'],
-  4: ['G4', 'D4', 'B4', 'A4', 'B4', 'D5', 'A5', 'G5'],
-  5: ['A4', 'D4', 'C4', 'G4', 'E4', 'C5', 'A5', 'E5'],
-  6: ['Bb4', 'D4', 'C4', 'G4', 'F4', 'C5', 'Bb5', 'F5'],
-  7: ['Bb4', 'Eb4', 'C4', 'G4', 'F4', 'D5', 'Bb5', 'Eb5'],
-  8: ['Ab4', 'Eb4', 'C4', 'G4', 'Ab4', 'D5', 'Ab5', 'Eb5'],
-  9: ['Db4', 'F4', 'C4', 'Ab4', 'Bb4', 'Db5', 'Ab5', 'F5'],
-  10: ['B4', 'F#4', 'D#4', 'C#4', 'A4', 'B5', 'D#5', 'F#5'],
-  11: ['E4', 'C4', 'G#4', 'D4', 'Bb4', 'E5', 'G#5', 'B5'],
-  12: ['C4', 'G4', 'E4', 'D4', 'B4', 'C5', 'E5', 'G5'],
-  13: ['C4', 'G4', 'F4', 'D4', 'A4', 'C5', 'F5', 'F5'],
-  14: ['D4', 'A4', 'F4', 'D4', 'A4', 'C5', 'F5', 'D5'],
-  15: ['F4', 'G4', 'B4', 'D4', 'G4', 'D5', 'G5', 'G5'],
-  16: ['G4', 'D4', 'B4', 'A4', 'B4', 'D5', 'A5', 'G5'],
-  17: ['A4', 'D4', 'C4', 'G4', 'E4', 'C5', 'A5', 'E5'],
-  18: ['Bb4', 'D4', 'C4', 'G4', 'F4', 'C5', 'Bb5', 'F5'],
-  19: ['Bb4', 'Eb4', 'C4', 'G4', 'F4', 'D5', 'Bb5', 'Eb5'],
-  20: ['Ab4', 'Eb4', 'C4', 'G4', 'Ab4', 'D5', 'Ab5', 'Eb5'],
-  21: ['Db4', 'F4', 'C4', 'Ab4', 'Bb4', 'Db5', 'Ab5', 'F5'],
-  22: ['B4', 'F#4', 'D#4', 'C#4', 'A4', 'B5', 'D#5', 'F#5'],
-  23: ['E4', 'C4', 'G#4', 'D4', 'Bb4', 'E5', 'G#5', 'B5'],
+  0:  ['C',  'G',  'E',  'D',  'B',  'C',  'E',  'G' ],
+  1:  ['C',  'G',  'F',  'D',  'A',  'C',  'F',  'F' ],
+  2:  ['D',  'A',  'F',  'D',  'A',  'C',  'F',  'D' ],
+  3:  ['F',  'G',  'B',  'D',  'G',  'D',  'G',  'G' ],
+  4:  ['G',  'D',  'B',  'A',  'B',  'D',  'A',  'G' ],
+  5:  ['A',  'D',  'C',  'G',  'E',  'C',  'A',  'E' ],
+  6:  ['Bb', 'D',  'C',  'G',  'F',  'C',  'Bb', 'F' ],
+  7:  ['Bb', 'Eb', 'C',  'G',  'F',  'D',  'Bb', 'Eb'],
+  8:  ['Ab', 'Eb', 'C',  'G',  'Ab', 'D',  'Ab', 'Eb'],
+  9:  ['Db', 'F',  'C',  'Ab', 'Bb', 'Db', 'Ab', 'F' ],
+  10: ['B',  'F#', 'D#', 'C#', 'A',  'B',  'D#', 'F#'],
+  11: ['E',  'C',  'G#', 'D',  'Bb', 'E',  'G#', 'B' ],
+  12: ['C',  'G',  'E',  'D',  'B',  'C',  'E',  'G' ],
+  13: ['C',  'G',  'F',  'D',  'A',  'C',  'F',  'F' ],
+  14: ['D',  'A',  'F',  'D',  'A',  'C',  'F',  'D' ],
+  15: ['F',  'G',  'B',  'D',  'G',  'D',  'G',  'G' ],
+  16: ['G',  'D',  'B',  'A',  'B',  'D',  'A',  'G' ],
+  17: ['A',  'D',  'C',  'G',  'E',  'C',  'A',  'E' ],
+  18: ['Bb', 'D',  'C',  'G',  'F',  'C',  'Bb', 'F' ],
+  19: ['Bb', 'Eb', 'C',  'G',  'F',  'D',  'Bb', 'Eb'],
+  20: ['Ab', 'Eb', 'C',  'G',  'Ab', 'D',  'Ab', 'Eb'],
+  21: ['Db', 'F',  'C',  'Ab', 'Bb', 'Db', 'Ab', 'F' ],
+  22: ['B',  'F#', 'D#', 'C#', 'A',  'B',  'D#', 'F#'],
+  23: ['E',  'C',  'G#', 'D',  'Bb', 'E',  'G#', 'B' ],
 };
 
 // ========================================

--- a/src/engine/melodyGenerator.ts
+++ b/src/engine/melodyGenerator.ts
@@ -11,12 +11,14 @@ export interface RobotMelodyEvent {
   startStep: number; // 1..16 (8th-note position in 2-measure loop)
   length: NoteDuration; // Note duration
   noteIndex: number; // 0..7 (maps into availableNotes palette)
+  octave: number;   // Concrete octave assigned at spawn time
 }
 
 export interface MelodyGeneratorOptions {
   events?: number; // Number of notes (default: 4-12)
   rand?: () => number; // RNG for testing (default: Math.random)
   syncopationBias?: number; // 0-1, off-beat preference (default: 0.4)
+  octaveRange?: [number, number]; // [min, max] octave band for this robot
 }
 
 // ========================================
@@ -25,6 +27,9 @@ export interface MelodyGeneratorOptions {
 const MIN_EVENTS = 4;
 const MAX_EVENTS = 12;
 const DEFAULT_SYNCOPATION_BIAS = 0.4;
+/** Probability that a successive note jumps more than one octave (when range allows). */
+const OCTAVE_JUMP_CHANCE = 0.15;
+const DEFAULT_OCTAVE_RANGE: [number, number] = [3, 4];
 
 const NOTE_INDEX_WEIGHTS = [0.35, 0.2, 0.15, 0.1, 0.07, 0.06, 0.04, 0.03];
 const LENGTH_WEIGHTS = [0.5, 0.25, 0.15, 0.1];
@@ -50,10 +55,26 @@ export function generateMelodyForRobot(
     opts?.events ?? MIN_EVENTS + Math.floor(rand() * (MAX_EVENTS - MIN_EVENTS + 1));
   const syncopationBias = opts?.syncopationBias ?? DEFAULT_SYNCOPATION_BIAS;
 
+  const [octMin, octMax] = opts?.octaveRange ?? DEFAULT_OCTAVE_RANGE;
+  // Seed currentOctave to a random value within the robot's range
+  let currentOctave = octMin + Math.floor(rand() * (octMax - octMin + 1));
+
   const melody: RobotMelodyEvent[] = [];
   const usedSlots = new Set<number>();
 
   for (let i = 0; i < eventsCount; i++) {
+    // 15% chance to jump to a non-adjacent octave (requires span of at least 2)
+    if (i > 0 && rand() < OCTAVE_JUMP_CHANCE) {
+      const jumpCandidates: number[] = [];
+      for (let o = octMin; o <= octMax; o++) {
+        if (Math.abs(o - currentOctave) > 1) jumpCandidates.push(o);
+      }
+      if (jumpCandidates.length > 0) {
+        currentOctave = jumpCandidates[Math.floor(rand() * jumpCandidates.length)];
+      }
+      // Range too narrow to jump — stay on current octave
+    }
+
     // Pick step position (with syncopation bias)
     const useOffBeat = rand() < syncopationBias;
     const candidateSteps = useOffBeat ? OFF_BEAT_STEPS : ON_BEAT_STEPS;
@@ -79,6 +100,7 @@ export function generateMelodyForRobot(
       startStep,
       length,
       noteIndex,
+      octave: currentOctave,
     });
   }
 

--- a/src/engine/pitchUtils.test.ts
+++ b/src/engine/pitchUtils.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { applyOctaveOffset } from './pitchUtils';
+
+describe('applyOctaveOffset', () => {
+  it('returns same note for offset 0', () => {
+    expect(applyOctaveOffset('C4', 0)).toBe('C4');
+    expect(applyOctaveOffset('G#5', 0)).toBe('G#5');
+  });
+
+  it('subtracts octaves correctly', () => {
+    expect(applyOctaveOffset('C4', 2)).toBe('C2');
+    expect(applyOctaveOffset('G#5', 1)).toBe('G#4');
+  });
+
+  it('clamps octave to minimum 1', () => {
+    expect(applyOctaveOffset('E1', 2)).toBe('E1');
+    expect(applyOctaveOffset('A2', 5)).toBe('A1');
+  });
+
+  it('returns original when note has no octave digits', () => {
+    expect(applyOctaveOffset('C', 1)).toBe('C');
+  });
+});

--- a/src/engine/pitchUtils.ts
+++ b/src/engine/pitchUtils.ts
@@ -1,0 +1,18 @@
+/**
+ * Apply an octave offset to a Tone.js pitch string (e.g. "C4" -> "C2").
+ * Clamps octave to a minimum of 1.
+ */
+export function applyOctaveOffset(note: string, offset: number): string {
+  if (!offset || offset === 0) return note;
+
+  const m = note.match(/(\d+)$/);
+  if (!m) return note;
+
+  const octave = parseInt(m[1], 10);
+  if (Number.isNaN(octave)) return note;
+
+  const newOctave = Math.max(1, octave - offset);
+  return note.slice(0, m.index) + String(newOctave);
+}
+
+export default applyOctaveOffset;

--- a/src/systems/spawnSystem.test.ts
+++ b/src/systems/spawnSystem.test.ts
@@ -61,7 +61,6 @@ describe('spawnSystem', () => {
         'FMSynth',
         'PolySynth',
         'DuoSynth',
-        'PluckSynth',
       ]).toContain(attrs.synthType);
     });
 
@@ -195,9 +194,9 @@ describe('spawnSystem', () => {
       }));
       const { addRobot } = useOceanStore.getState();
       // seed store with max robots
-      addRobot({ id: 'a', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, createdAt: 1000 });
-      addRobot({ id: 'b', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, createdAt: 2000 });
-      addRobot({ id: 'c', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, createdAt: 3000 });
+      addRobot({ id: 'a', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 1000 });
+      addRobot({ id: 'b', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 2000 });
+      addRobot({ id: 'c', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 3000 });
       expect(useOceanStore.getState().robots.length).toBe(3);
 
       spawnRobot();
@@ -211,7 +210,7 @@ describe('spawnSystem', () => {
       // set max and min equal
       useOceanStore.setState({ settings: { bpm: 120, maxRobots: 1, minRobots: 1 } } as OceanStore);
       const { addRobot } = useOceanStore.getState();
-      addRobot({ id: 'only', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, createdAt: 123 });
+      addRobot({ id: 'only', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 123 });
 
       spawnRobot();
       expect(useOceanStore.getState().robots.length).toBe(1);

--- a/src/systems/spawnSystem.ts
+++ b/src/systems/spawnSystem.ts
@@ -164,6 +164,18 @@ export function generateAudioAttributes(): AudioAttributes {
 }
 
 /**
+ * Pick an octave range [min, max] for a robot based on its pitch bucket.
+ * Low  robots (< 150 Hz) → [2, 3] — bass register
+ * Mid  robots (< 450 Hz) → [3, 4] — mid register
+ * High robots (≥ 450 Hz) → [4, 5] — treble register
+ */
+export function pickOctaveRange(pitchRange: { min: number; max: number }): [number, number] {
+  if (pitchRange.max < 150) return [2, 3];
+  if (pitchRange.max < 450) return [3, 4];
+  return [4, 5];
+}
+
+/**
  * Spawn a new robot with randomized attributes
  * Enforces MAX_ROBOTS limit and registers melody with AudioEngine
  */
@@ -193,15 +205,19 @@ export function spawnRobot(): void {
     return;
   }
 
-  // Generate robot attributes
+  // Generate audio attributes first so octaveRange can be derived and passed to melody generator
+  const audioAttributes = generateAudioAttributes();
+  const octaveRange = pickOctaveRange(audioAttributes.pitchRange);
+
   const robot: Robot = {
     id: crypto.randomUUID(),
     state: RobotState.Idle,
     position: generateSpawnPosition(),
     destination: null,
     direction: 'right', // Default facing direction (will be updated by idleSystem)
-    melody: generateMelodyForRobot(),
-    audioAttributes: generateAudioAttributes(),
+    melody: generateMelodyForRobot({ octaveRange }),
+    audioAttributes,
+    octaveRange,
     createdAt: Date.now(),
   };
 

--- a/src/types/Robot.ts
+++ b/src/types/Robot.ts
@@ -60,6 +60,7 @@ export interface MelodyEvent {
   startStep: number;                    // 1-16 (8th-note grid position)
   length: NoteDuration;                 // Note duration
   noteIndex: number;                    // 0-7 (index into available harmony palette)
+  octave: number;                       // Concrete octave assigned at spawn time
 }
 
 /**
@@ -75,6 +76,8 @@ export interface Robot {
   direction: 'left' | 'right';     // Facing direction (horizontal orientation)
   melody: MelodyEvent[];
   audioAttributes: AudioAttributes;
+  /** Octave range [min, max] this robot plays within. Melody events store concrete octaves within this range. */
+  octaveRange: [number, number];
   layer?: 'background' | 'foreground'; // SVG rendering layer (default: foreground)
   createdAt: number;            // timestamp used for removal ordering
   /** Transport measure at which this robot last interacted (for cooldown tracking). */


### PR DESCRIPTION
Harmony palettes now store bare note names ('C', 'Bb') instead of full pitch strings ('C4', 'Bb5'). Each RobotMelodyEvent carries a concrete octave baked in at spawn time, derived from a per-robot octaveRange ([min, max]) based on its pitch bucket (bass/mid/treble).

At scheduling time AudioEngine composes the final note as

oteName + event.octave. This means harmony changes silently rotate the pitch class while each robot keeps its register stable.

- Strip octave digits from TIME_PITCHES in harmonySystem
- Add octave: number field to MelodyEvent / RobotMelodyEvent
- Add octaveRange: [number, number] to Robot type
- Add pickOctaveRange() to spawnSystem; pass range into melody generator
- melodyGenerator seeds a starting octave and applies 15% jump chance
- AudioEngine validates note strings before triggering synth
- Add pitchUtils.ts with applyOctaveOffset (+ tests)
- Update harmonySystem test expectation to match bare note format
- Update docs (HARMONY_SYSTEM.md, MELODY_SYSTEM.md, copilot-instructions)

closes #112

