### PR TITLE
feat(audio,visual): add layered audio/visual mapping and composite vo…

### DIFF
--- a/docs/AUDIO_SYSTEM.md
+++ b/docs/AUDIO_SYSTEM.md
@@ -180,6 +180,24 @@ Polyphony management controls the maximum number of simultaneous audio voices to
 
 **For complete implementation details, see [POLYPHONY_GUIDE.md](POLYPHONY_GUIDE.md).**
 
+## Layered / Composite Voices and Visual Mapping
+
+Pelagos-7 supports compact, spawn-time layered descriptors ("LayeredWave") that describe a small stack of timbral layers (oscillators or noise) and per-layer gains/detune/adsr. These descriptors are intentionally serializable and stored on the robot as a `visualAudioMap` so the visual system can deterministically derive appearance from audio without instantiating synths at render time.
+
+Key points:
+- A `LayeredWave` is a small JSON-like descriptor: `{ base: WaveformType, layers?: LayerDescriptor[] }`.
+- At spawn time the `spawnSystem` may create 1–3 layered presets and compute a gain-weighted averaged ADSR and compact `shapeParams` used by robot visuals.
+- The `AudioEngine` can create a runtime composite voice from a `LayeredWave` via `AudioEngine.createCompositeVoice()` and `AudioEngine.reserveVoice(robotId, layeredWave)`. Composite voices are routed into a per-robot sub-bus (panner -> gain -> filter -> master compressor) to avoid parameter bleed and allow safe per-robot control.
+- Composite voices expose `triggerAttackRelease`, `set`, and `dispose` semantics similar to single synths so scheduling code uses the same high-level APIs.
+- Because `visualAudioMap` is serializable and stored on spawn, visuals can be rendered identically in non-audio contexts (editor previews, snapshots) without requiring Tone.js objects.
+
+Recommended usage:
+- At spawn: generate and persist a compact `visualAudioMap` on the robot. This contains the `LayeredWave`, `averagedADSR`, `averagedGain`, `shapeParams`, and per-layer `layerVisuals`.
+- At audio init: attempt `AudioEngine.reserveVoice(robotId, layeredWave)` to allocate an isolated composite voice. If reservation fails (pool exhausted), AudioEngine will gracefully fall back to shared pool voices.
+- In components: prefer reading `visualAudioMap` (or the `robotVisualMapper`) for visual properties; do not instantiate synths in components.
+
+See `src/types/layeredAudio.ts` and `src/systems/spawnSystem.ts` for the canonical descriptor shape and spawn-time averaging logic.
+
 ## Scheduling Patterns
 
 Audio scheduling in Pelagos-7 uses Tone.js Transport for sample-accurate, musically-aligned timing.

--- a/docs/ROBOT_DESIGN.md
+++ b/docs/ROBOT_DESIGN.md
@@ -158,6 +158,23 @@ function calculateDetailLevel(filterFreq: number): number {
 }
 ```
 
+## Spawn-time Visual Mapping (`visualAudioMap`)
+
+The audio systems produce a compact `visualAudioMap` at spawn time that is stored on each robot's `audioAttributes`. This map is intentionally serializable and contains a small `LayeredWave` descriptor plus derived visuals used by the rendering pipeline:
+
+- `layeredWave` — compact layered descriptor (base + optional per-layer gain/detune/adsr)
+- `averagedADSR` — gain-weighted averaged ADSR envelope derived from layers
+- `averagedGain` — overall loudness proxy used for color/luminance mapping
+- `shapeParams` — compact shape values (`scale`, `roundness`, `detail`) in 0..1 used by the SVG components
+- `layerVisuals` — optional per-layer color/scale/offset hints for greebles and lights
+
+Practical guidelines:
+- Prefer `visualAudioMap` when rendering — it guarantees deterministic visuals in editor previews and snapshots without initializing Tone.js.
+- Keep the map serializable; never store Tone.js nodes or functions in state.
+- The runtime `AudioEngine` may create an isolated composite synth from the same `LayeredWave` for real synthesis, but the visual system continues to use the spawn-time map for deterministic presentation.
+
+See `src/types/layeredAudio.ts`, `src/systems/spawnSystem.ts` and `src/components/robot/robotVisualMapper.ts` for the canonical shapes and mapping logic.
+
 ## Accessibility
 
 ### Color Contrast

--- a/docs/poc_guides/M7a-issues.md
+++ b/docs/poc_guides/M7a-issues.md
@@ -1,0 +1,187 @@
+---
+name: Feature
+about: New feature or enhancement
+title: '[M7.1] LayeredWave & Visual Types'
+labels: audio, visual, enhancement
+assignees: ''
+---
+
+## Feature Description
+Add typed data model for layered audio and the canonical visual mapping used by robots. Define `LayeredWave`, `LayerVisual`, and `ShapeParams` and extend `AudioAttributes` so spawn-time data includes a compact `visualAudioMap`.
+
+## Implementation Details
+- Types in `src/types/`: add `LayeredWave`, `LayerVisual`, `ShapeParams` and extend `AudioAttributes`.
+- `LayeredWave` should allow `base: WaveformType`, optional `layers: Array<{ type: WaveformType|'noise', gain?: number, detune?: number, adsr?: ADSTRaw }>`.
+
+## Technical Notes
+- Keep types serializable and small; visual mapping is derived at spawn-time and stored on the robot object.
+
+## Acceptance Criteria
+- [ ] Types added in `src/types/` and TypeScript compiles.
+- [ ] Spawned robots include `visualAudioMap` in their audio attributes.
+
+---
+
+---
+name: Feature
+about: New feature or enhancement
+title: '[M7.2] Composite Voice Factory in AudioEngine'
+labels: audio, enhancement
+assignees: ''
+---
+
+## Feature Description
+Implement a composite voice factory in `AudioEngine` that constructs a single reserved voice containing multiple oscillators and optional `NoiseSynth`, mixed via per-voice `Gain` nodes.
+
+## Implementation Details
+- Add a factory in `src/engine/AudioEngine.ts` to create composite voices with multiple `Oscillator` nodes, per-layer gain, and an optional `NoiseSynth` layer.
+- Expose `triggerAttackRelease(note, dur, time, velocity)` and `set(params)` on the composite voice.
+
+## Technical Notes
+- Composite voices should be routed into the existing audio graph via a per-voice output node so effects/panning behave like single voices.
+
+## Acceptance Criteria
+- [ ] New factory exists and is covered by unit tests that assert the proper construction of oscillators and nodes.
+
+---
+
+---
+name: Feature
+about: New feature or enhancement
+title: '[M7.3] reserveVoice API & Per-Robot Sub-Bus'
+labels: audio, enhancement
+assignees: ''
+---
+
+## Feature Description
+Extend `AudioEngine.reserveVoice()` to accept a `LayeredWave` descriptor and ensure reserved composite voices route into a per-robot sub-bus (Gain → Filter → Effects).
+
+## Implementation Details
+- Update `reserveVoice()` signature and allocation path to accept layered descriptors.
+- Create or reuse a per-robot sub-bus where each reserved voice routes; ensure effect sends and panners attach to the sub-bus.
+
+## Acceptance Criteria
+- [ ] `reserveVoice()` accepts layered descriptors and instantiates composite voices.
+- [ ] Tests verify no global parameter bleed (i.e., changes affect only the reserved robot voice/sub-bus).
+
+---
+
+---
+name: Feature
+about: New feature or enhancement
+title: '[M7.4] Spawn Presets + ADSR Normalization & Averaging'
+labels: audio, enhancement
+assignees: ''
+---
+
+## Feature Description
+Update `spawnSystem.generateAudioAttributes()` to produce layered presets (max 3 layers by default), normalize ADSR with predefined maxima, and compute gain-weighted averaged ADSR values used for visuals.
+
+## Implementation Details
+- Defaults: max layers = 3; ADSR maxima: attack=2s, decay=2s, release=5s.
+- Normalize per-layer ADSR to 0..1 using maxima, compute weighted average by layer gain for attack/decay/sustain/release, and map averaged results into `ShapeParams`.
+
+## Acceptance Criteria
+- [ ] Spawned robots include layered presets and `visualAudioMap` with averaged ADSR.
+- [ ] Unit tests verify the averaging formulas and normalization.
+
+---
+
+---
+name: Feature
+about: New feature or enhancement
+title: '[M7.5] Visual Audio Mapper Adapter'
+labels: visual, enhancement
+assignees: ''
+---
+
+## Feature Description
+Add `robotVisualMapper` that converts `visualAudioMap` → `bodyShapeProps`, `greebleProps`, and `lightsProps` with canonical mapping rules and body-type fallbacks.
+
+## Implementation Details
+- Implement `src/components/robot/robotVisualMapper.ts` that produces component-friendly props from the canonical map.
+- Provide clear fallbacks so all body types can consume the same output safely.
+
+## Acceptance Criteria
+- [ ] Adapter exists and has unit tests demonstrating mapping behavior across representative inputs.
+
+---
+
+---
+name: Feature
+about: New feature or enhancement
+title: '[M7.6] Robot Components — Accept Audio-Derived Props'
+labels: visual, enhancement
+assignees: ''
+---
+
+## Feature Description
+Update robot body components (`RobotBody`, `RobotOrganic`, etc.) to accept `bodyShapeProps`, `greebleProps`, and `lightsProps`, and animate shape using averaged ADSR-derived `ShapeParams`.
+
+## Implementation Details
+- Update component props and implement animation hooks (GSAP or existing helpers) to animate shape transitions using `ShapeParams`.
+- Keep per-body fallbacks so bodies without certain features degrade gracefully.
+
+## Acceptance Criteria
+- [ ] Components accept new props and render without console errors.
+- [ ] Snapshot or render smoke tests for each body type with sample props pass.
+
+---
+
+---
+name: Feature
+about: New feature or enhancement
+title: '[M7.7] AudioVisual Inspector UI'
+labels: debug, enhancement
+assignees: ''
+---
+
+## Feature Description
+Create an inspector UI at `src/components/debug/AudioVisualInspector.tsx` to preview layered-wave presets, toggle layers, edit gains, and preview the averaged ADSR and resulting body shape.
+
+## Implementation Details
+- Inspector mounts in the debug area and exposes controls for up to 3 layers, layer gain, and presets. Preview pane shows a live `visualAudioMap` → `Robot` render.
+
+## Acceptance Criteria
+- [ ] Inspector mounts with no console errors and updates preview when controls change.
+
+---
+
+---
+name: Feature
+about: New feature or enhancement
+title: '[M7.8] Tests & Documentation'
+labels: test, docs
+assignees: ''
+---
+
+## Feature Description
+Add unit tests for types, spawn normalization, composite voice behavior, and mapping rules. Update `docs/AUDIO_SYSTEM.md` and `docs/ROBOT_DESIGN.md` with usage examples, defaults, and guardrails.
+
+## Implementation Details
+- Add tests under `src/engine/` and `src/systems/` as appropriate; include render smoke tests for robot components.
+- Update docs with defaults: noise enabled, max layers=3, ADSR maxima = 2/2/5.
+
+## Acceptance Criteria
+- [ ] New tests run locally via `vitest` and pass.
+- [ ] Documentation updated with mapping rules and examples.
+
+---
+
+---
+name: Feature
+about: New feature or enhancement
+title: '[M7.9] Performance Guidance & Pool Limits'
+labels: perf, docs
+assignees: ''
+---
+
+## Feature Description
+Document recommended max layers and synth-pool guidance. Add a perf smoke test to spawn many layered robots and observe CPU/memory impact.
+
+## Implementation Details
+- Provide guidance in docs; add a script or test harness to spawn up to `MAX_POLYPHONY` robots with layered voices to observe performance characteristics.
+
+## Acceptance Criteria
+- [ ] Docs updated with recommended defaults and pool sizing guidance.
+- [ ] Perf smoke test added that can be run locally.

--- a/src/components/debug/AudioVisualInspector.test.tsx
+++ b/src/components/debug/AudioVisualInspector.test.tsx
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import AudioVisualInspector from './AudioVisualInspector';
+
+describe('AudioVisualInspector', () => {
+  it('exports a component function', () => {
+    expect(typeof AudioVisualInspector).toBe('function');
+  });
+});

--- a/src/components/debug/AudioVisualInspector.tsx
+++ b/src/components/debug/AudioVisualInspector.tsx
@@ -1,0 +1,102 @@
+import React, { useState, useMemo } from 'react';
+import mapVisualAudioToProps from '../robot/robotVisualMapper';
+import { RobotSleek } from '../robot/RobotSleek';
+import { RobotOrganic } from '../robot/RobotOrganic';
+import { RobotAngular } from '../robot/RobotAngular';
+import { RobotIndustrial } from '../robot/RobotIndustrial';
+import type { LayeredWave } from '../../types/layeredAudio';
+
+const WAVEFORMS = ['sine', 'square', 'triangle', 'sawtooth'] as const;
+type Waveform = typeof WAVEFORMS[number];
+
+export function AudioVisualInspector(): React.ReactElement {
+  const [base, setBase] = useState<LayeredWave['base']>('sine');
+  const [numLayers, setNumLayers] = useState(2);
+  const [layers, setLayers] = useState(() =>
+    Array.from({ length: 3 }, (_, i) => ({ type: WAVEFORMS[i % WAVEFORMS.length], gain: 0.6 + i * 0.2 }))
+  );
+
+  const vm: LayeredWave = useMemo(() => ({ base, layers: layers.slice(0, numLayers) }), [base, layers, numLayers]);
+
+  const mapped = mapVisualAudioToProps({ layeredWave: vm, averagedGain: layers.reduce((s, l) => s + (l.gain ?? 1), 0) / numLayers, shapeParams: undefined });
+
+  function setLayerGain(index: number, value: number) {
+    setLayers((prev) => prev.map((l, i) => (i === index ? { ...l, gain: value } : l)));
+  }
+
+  function setLayerType(index: number, type: Waveform) {
+    setLayers((prev) => prev.map((l, i) => (i === index ? { ...l, type } : l)));
+  }
+
+  const variants = [
+    { name: 'Sleek', Component: RobotSleek },
+    { name: 'Organic', Component: RobotOrganic },
+    { name: 'Angular', Component: RobotAngular },
+    { name: 'Industrial', Component: RobotIndustrial },
+  ];
+
+  return (
+    <div style={{ padding: 12, fontFamily: 'Inter, system-ui, sans-serif' }}>
+      <h3 style={{ margin: '0 0 8px 0' }}>AudioVisual Inspector (M7.7)</h3>
+
+      <div style={{ display: 'flex', gap: 12, marginBottom: 12 }}>
+        <label>
+          Base
+          <select value={base} onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setBase(e.target.value as Waveform)} style={{ marginLeft: 8 }}>
+            {WAVEFORMS.map((w) => (
+              <option key={w} value={w}>
+                {w}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Layers
+          <input type="range" min={1} max={3} value={numLayers} onChange={(e) => setNumLayers(Number(e.target.value))} style={{ marginLeft: 8 }} />
+        </label>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8, marginBottom: 12 }}>
+        {Array.from({ length: numLayers }, (_, i) => (
+          <div key={i} style={{ border: '1px solid #e6e6e6', padding: 8, borderRadius: 6 }}>
+            <div style={{ fontSize: 12, marginBottom: 6 }}>Layer {i + 1}</div>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <select value={layers[i]?.type} onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setLayerType(i, e.target.value as Waveform)}>
+                {WAVEFORMS.map((w) => (
+                  <option key={w} value={w}>
+                    {w}
+                  </option>
+                ))}
+              </select>
+              <input type="range" min={0} max={2} step={0.05} value={layers[i]?.gain ?? 1} onChange={(e) => setLayerGain(i, Number(e.target.value))} />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: 'flex', gap: 12 }}>
+        <div style={{ flex: '0 0 360px', border: '1px solid #eee', padding: 8, borderRadius: 6 }}>
+          <div style={{ fontSize: 12, marginBottom: 6 }}>Preview</div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 8 }}>
+            {variants.map(({ name, Component }) => (
+              <div key={name} style={{ border: '1px solid rgba(0,0,0,0.04)', padding: 6, borderRadius: 6 }}>
+                <div style={{ fontSize: 11, marginBottom: 6 }}>{name}</div>
+                <div style={{ width: 160, height: 120 }}>
+                  <Component colors={{ primary: '#6aa6c7', secondary: '#7b6f9a', accent: '#ffd27f' }} scale={1} detailLevel={mapped.bodyShapeProps.detail} shapeParams={{ torsoAspect: 1, appendageLength: 1, scaleBias: 0 }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ flex: 1, border: '1px solid #eee', padding: 8, borderRadius: 6 }}>
+          <div style={{ fontSize: 12, marginBottom: 6 }}>Mapped Props</div>
+          <pre style={{ fontSize: 12, maxHeight: 240, overflow: 'auto' }}>{JSON.stringify(mapped, null, 2)}</pre>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AudioVisualInspector;

--- a/src/components/robot/RobotBody.tsx
+++ b/src/components/robot/RobotBody.tsx
@@ -16,6 +16,7 @@ import {
   calculateDetailLevel,
   applyLightnessMultiplier,
 } from './robotVisualHelpers';
+import mapVisualAudioToProps from './robotVisualMapper';
 import type { RobotColors, RobotSVGComponent, ShapeParams, MicroVariants } from './robotVisualHelpers';
 import { useOceanStore } from '../../stores/oceanStore';
 
@@ -37,16 +38,30 @@ export const RobotBody = memo(function RobotBody({ robot }: RobotBodyProps) {
   const lightnessMultiplier = useOceanStore((s) => s.lightnessMultiplier);
 
   const visual = useMemo(() => {
-    const { synthType, adsr, pitchRange, filterFreq } = robot.audioAttributes;
+    const { synthType, adsr, pitchRange, filterFreq, visualAudioMap } = robot.audioAttributes;
 
     const baseColors = generateColors(robot.audioAttributes);
     const colors = applyLightnessMultiplier(baseColors, lightnessMultiplier);
-    const { shapeParams, microVariants } = shapeParamsFromAudio(robot.audioAttributes);
 
-    // Greeble values
-    const detail = calculateDetailLevel(filterFreq);
-    const greebleCount = calculateGreebleCount(filterFreq, detail, robot.audioAttributes.waveform, adsr);
-    const greebleSize = calculateGreebleSize(adsr.sustain);
+    // Prefer the spawn-time visualAudioMap via mapper when available.
+    const mapped = mapVisualAudioToProps(visualAudioMap);
+
+    // Convert mapped bodyShapeProps (scale, roundness, detail) into the
+    // component-specific ShapeParams expected by SVG components.
+    const bodyShape = mapped.bodyShapeProps ?? { scale: 0.5, roundness: 0.5, detail: 0.3 };
+    const shapeParams = {
+      torsoAspect: Math.max(0.7, Math.min(1.3, 0.85 + (bodyShape.roundness - 0.5) * 0.6)),
+      appendageLength: Math.max(0.6, Math.min(1.4, 0.8 + bodyShape.detail * 0.9)),
+      scaleBias: Math.max(-0.4, Math.min(0.4, (bodyShape.scale - 0.5) * 0.6)),
+    };
+
+    const microVariants = shapeParamsFromAudio(robot.audioAttributes).microVariants;
+
+    // Greeble values come from mapped greebleProps when present, else fall back
+    // to the original deterministic calculations.
+    const detail = bodyShape.detail ?? calculateDetailLevel(filterFreq);
+    const greebleCount = mapped.greebleProps?.count ?? calculateGreebleCount(filterFreq, detail, robot.audioAttributes.waveform, adsr);
+    const greebleSize = mapped.greebleProps?.scale ? Math.max(1, Math.round(mapped.greebleProps.scale * 6)) : calculateGreebleSize(adsr.sustain);
     const greeblePersistence = calculateGreeblePersistence(adsr.release);
     const greeblePlacementBias = calculateGreeblePlacementBias(adsr.decay, adsr.release);
 
@@ -61,6 +76,7 @@ export const RobotBody = memo(function RobotBody({ robot }: RobotBodyProps) {
       greebleSize,
       greeblePersistence,
       greeblePlacementBias,
+      lightsProps: mapped.lightsProps,
     };
   }, [robot.audioAttributes, lightnessMultiplier]) as {
     Component: RobotSVGComponent;
@@ -73,6 +89,7 @@ export const RobotBody = memo(function RobotBody({ robot }: RobotBodyProps) {
     greebleSize: number;
     greeblePersistence: number;
     greeblePlacementBias: number;
+    lightsProps?: { intensity: number; color: string };
   };
 
   const { Component, colors, scale, detailLevel, shapeParams, microVariants, greebleCount, greebleSize, greeblePersistence, greeblePlacementBias } = visual;

--- a/src/components/robot/RobotPreview.tsx
+++ b/src/components/robot/RobotPreview.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { RobotOrganic } from './RobotOrganic';
+import { RobotIndustrial } from './RobotIndustrial';
+import { RobotAngular } from './RobotAngular';
+import { RobotSleek } from './RobotSleek';
+
+export function RobotPreview(): React.ReactElement {
+  const [detailLevel, setDetailLevel] = useState(0.8);
+  const [scale, setScale] = useState(1);
+  const [colors, setColors] = useState({ primary: '#6aa6c7', secondary: '#7b6f9a', accent: '#ffd27f' });
+  const [showGreebles, setShowGreebles] = useState(true);
+  const [showVents, setShowVents] = useState(true);
+  const [showSideLights, setShowSideLights] = useState(true);
+  const [showHalo, setShowHalo] = useState(true);
+
+  const variants = [
+    { name: 'Organic', Component: RobotOrganic },
+    { name: 'Industrial', Component: RobotIndustrial },
+    { name: 'Angular', Component: RobotAngular },
+    { name: 'Sleek', Component: RobotSleek },
+  ];
+
+  return (
+    <div className="robot-preview" style={{ fontFamily: 'Inter, system-ui, sans-serif', padding: 12 }}>
+      <h3 style={{ margin: '0 0 12px 0' }}>Robot Visual Preview</h3>
+
+      <div style={{ display: 'flex', gap: 12, marginBottom: 12, alignItems: 'center' }}>
+        <label style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          Detail
+          <input type="range" min={0} max={1} step={0.1} value={detailLevel} onChange={(e) => setDetailLevel(Number(e.target.value))} />
+        </label>
+        <label style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          Scale
+          <input type="range" min={0.6} max={1.4} step={0.1} value={scale} onChange={(e) => setScale(Number(e.target.value))} />
+        </label>
+        <label style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          Primary
+          <input type="color" value={colors.primary} onChange={(e) => setColors({ ...colors, primary: e.target.value })} />
+        </label>
+        <label style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          Secondary
+          <input type="color" value={colors.secondary} onChange={(e) => setColors({ ...colors, secondary: e.target.value })} />
+        </label>
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, marginBottom: 12 }}>
+        <label><input type="checkbox" checked={showGreebles} onChange={(e) => setShowGreebles(e.target.checked)} /> Greebles</label>
+        <label><input type="checkbox" checked={showVents} onChange={(e) => setShowVents(e.target.checked)} /> Vents</label>
+        <label><input type="checkbox" checked={showSideLights} onChange={(e) => setShowSideLights(e.target.checked)} /> Side lights</label>
+        <label><input type="checkbox" checked={showHalo} onChange={(e) => setShowHalo(e.target.checked)} /> Light halo</label>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 16 }}>
+        {variants.map(({ name, Component }) => (
+          <div key={name} style={{ border: '1px solid rgba(0,0,0,0.06)', padding: 8, borderRadius: 8 }}>
+            <div style={{ fontSize: 12, marginBottom: 8 }}>{name}</div>
+            <div
+              className={`preview-card ${!showGreebles ? 'no-greebles' : ''} ${!showVents ? 'no-vents' : ''} ${!showSideLights ? 'no-sidelights' : ''} ${!showHalo ? 'no-halo' : ''}`}
+              style={{ width: 160, height: 120 }}
+            >
+              <Component colors={colors} scale={scale} detailLevel={detailLevel} />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        .preview-card .greebles { display: var(--greebles-display, block); }
+        .preview-card.no-greebles .greebles { display: none; }
+        .preview-card.no-vents .vent { display: none; }
+        .preview-card.no-sidelights .side-lights { display: none; }
+        .preview-card.no-halo .status-light-glow, .preview-card.no-halo .side-light-glow { opacity: 0 !important; }
+      `}</style>
+    </div>
+  );
+}
+
+export default RobotPreview;

--- a/src/components/robot/robotVisualMapper.test.ts
+++ b/src/components/robot/robotVisualMapper.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import mapVisualAudioToProps from './robotVisualMapper';
+import type { VisualAudioMap } from '../../types/layeredAudio';
+
+describe('robotVisualMapper', () => {
+  it('returns defaults when vm is undefined', () => {
+    const out = mapVisualAudioToProps(undefined);
+    expect(out).toBeDefined();
+    expect(out.bodyShapeProps.scale).toBeGreaterThanOrEqual(0);
+    expect(out.greebleProps.count).toBeGreaterThanOrEqual(0);
+  });
+
+  it('maps shapeParams and averagedGain to lights and greebles', () => {
+    const vm: VisualAudioMap = {
+      averagedGain: 1.2,
+      shapeParams: { scale: 0.8, roundness: 0.7, detail: 0.9 },
+    };
+    const out = mapVisualAudioToProps(vm);
+    expect(out.bodyShapeProps.scale).toBeCloseTo(0.8, 3);
+    expect(out.greebleProps.count).toBeGreaterThanOrEqual(4);
+    expect(out.lightsProps.intensity).toBeGreaterThan(0);
+    expect(typeof out.lightsProps.color).toBe('string');
+  });
+});

--- a/src/components/robot/robotVisualMapper.ts
+++ b/src/components/robot/robotVisualMapper.ts
@@ -1,0 +1,52 @@
+import type { VisualAudioMap, ShapeParams } from '../../types/layeredAudio';
+
+/**
+ * Minimal adapter to convert the canonical `visualAudioMap` produced at spawn
+ * into component-friendly props: `bodyShapeProps`, `greebleProps`, `lightsProps`.
+ * Keep outputs serializable and small — components may animate these values.
+ */
+export function mapVisualAudioToProps(vm?: VisualAudioMap) {
+  // Fallback defaults for shape parameters if no audio mapping is present.
+  // If you change the mapping logic, update spawnSystem and docs for consistency.
+  const defaultShape: ShapeParams = { scale: 0.5, roundness: 0.5, detail: 0.3 };
+
+  if (!vm) {
+    return {
+      bodyShapeProps: { ...defaultShape },
+      greebleProps: { count: 2, scale: 0.5 },
+      lightsProps: { intensity: 0.4, color: '#ffffff' },
+    };
+  }
+
+  const shape = vm.shapeParams ?? defaultShape;
+
+  // Body shape mapping: pass through but clamp to 0..1 for safety.
+  // These props are used by SVG robot components for geometry.
+  const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+  const bodyShapeProps = {
+    scale: clamp01(shape.scale),
+    roundness: clamp01(shape.roundness),
+    detail: clamp01(shape.detail),
+  };
+
+  // Greebles: derive count from detail (more detail → more greebles)
+  // If you want more/less greebles, adjust the multiplier here.
+  const greebleCount = Math.max(0, Math.round(bodyShapeProps.detail * 6));
+  const greebleProps = {
+    count: greebleCount,
+    scale: clamp01(0.3 + bodyShapeProps.detail * 0.7),
+  };
+
+  // Lights: intensity is a blend of averagedGain (loudness) and detail (release time).
+  // Color is mapped from scale (attack time) for visual variety.
+  const intensity = clamp01((vm.averagedGain ?? 1) * 0.6 + bodyShapeProps.detail * 0.4);
+  const hue = Math.round(200 - bodyShapeProps.scale * 120); // 80..200
+  const lightsProps = {
+    intensity,
+    color: `hsl(${hue} 80% 60%)`,
+  };
+
+  return { bodyShapeProps, greebleProps, lightsProps };
+}
+
+export default mapVisualAudioToProps;

--- a/src/engine/AudioEngine.test.ts
+++ b/src/engine/AudioEngine.test.ts
@@ -356,3 +356,45 @@ describe('AudioEngine - Reservation & Isolation (focused)', () => {
     expect(result).toBe(true);
   });
 });
+
+describe('AudioEngine - Composite Voices (Layered)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    useOceanStore.setState({ settings: { bpm: 120, maxRobots: 6, minRobots: 1 } } as unknown as Record<string, unknown>);
+  });
+
+  it('can reserve a composite voice from a LayeredWave descriptor', async () => {
+    const { AudioEngine } = await import('./AudioEngine');
+    await AudioEngine.start();
+    const layered = { base: 'sine', layers: [{ type: 'sine', gain: 0.8 }] } as unknown as import('../types/layeredAudio').LayeredWave;
+    const ok = AudioEngine.reserveVoice('composite-robot-1', layered);
+    expect(ok).toBe(true);
+    const voice = AudioEngine.getVoiceForRobot('composite-robot-1');
+    expect(voice).not.toBeNull();
+  });
+
+  it('triggerWithCap uses composite voice when reserved and returns true', async () => {
+    const { AudioEngine, triggerWithCap } = await import('./AudioEngine');
+    await AudioEngine.start();
+    const layered = { base: 'sine', layers: [{ type: 'sine', gain: 0.6 }] } as unknown as import('../types/layeredAudio').LayeredWave;
+    const ok = AudioEngine.reserveVoice('composite-robot-2', layered);
+    expect(ok).toBe(true);
+    const result = triggerWithCap({ robotId: 'composite-robot-2', note: 'C4', duration: '8n', time: 0 });
+    expect(result).toBe(true);
+  });
+
+  it('releases composite and cleans up internal maps on releaseVoice', async () => {
+    const { AudioEngine } = await import('./AudioEngine');
+    await AudioEngine.start();
+    const layered = { base: 'sine', layers: [{ type: 'sine', gain: 0.6 }] } as unknown as import('../types/layeredAudio').LayeredWave;
+    const ok = AudioEngine.reserveVoice('composite-robot-3', layered);
+    expect(ok).toBe(true);
+    // ensure voice exists
+    let voice = AudioEngine.getVoiceForRobot('composite-robot-3');
+    expect(voice).not.toBeNull();
+    // release and ensure it's removed
+    AudioEngine.releaseVoice('composite-robot-3');
+    voice = AudioEngine.getVoiceForRobot('composite-robot-3');
+    expect(voice).toBeNull();
+  });
+});

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -6,6 +6,7 @@ import gsap from 'gsap';
 import { useOceanStore } from '../stores/oceanStore';
 
 import type { NoteDuration, ADSREnvelope, SynthType, WaveformType, Robot } from '../types/Robot';
+import type { LayeredWave, LayerDescriptor } from '../types/layeredAudio';
 import { getAvailableNotes, scheduleHarmonyCycle, stopHarmonyCycle } from './harmonySystem';
 import { initBeatClock } from './beatClock';
 import type { RobotMelodyEvent } from './melodyGenerator';
@@ -39,6 +40,15 @@ interface MelodyEventEntry {
 type SynthPool = Record<string, Tone.PolySynth[]>;
 type PannerPool = Record<string, Tone.Panner[]>;
 
+// Minimal shape used for test/runtime fallbacks where Tone classes may be absent.
+interface MinimalToneNode {
+  connect: (target?: unknown) => unknown;
+  disconnect?: () => void;
+  toDestination?: () => void;
+  gain?: { value: number };
+  pan?: { value: number };
+}
+
 // ========================================
 // CONSTANTS
 // ========================================
@@ -50,6 +60,9 @@ const VELOCITY_VARIANCE_RATE = 0.15;
 const VELOCITY_VARIANCE_AMOUNT = 0.25;  // ±25% offset
 /** Minimum effective note velocity after clamping (prevents silent notes). */
 const VELOCITY_MIN = 0.05;
+
+// Lightweight record view of Tone to access constructors safely in test/runtime
+const toneRecord = Tone as unknown as Record<string, unknown>;
 
 // ========================================
 // MODULE STATE
@@ -82,6 +95,21 @@ const robotAttributeCache = new Map<string, {
   waveform?: WaveformType;
   masterVolume: number;
 }>();
+
+// Composite voices (created from LayeredWave descriptors) stored separately
+interface CompositeVoice {
+  output: Tone.Gain;
+  triggerAttackRelease: (note: string, dur: NoteDuration | string, time?: number, velocity?: number) => void;
+  set: (params: { layers?: Partial<LayerDescriptor>[]; outputGain?: number }) => void;
+  dispose?: () => void;
+}
+
+const compositeVoices: Map<string, {
+  composite: CompositeVoice;
+  panner: Tone.Panner;
+  busGain: Tone.Gain;
+  busFilter: Tone.Filter;
+}> = new Map();
 
 // ========================================
 // INTERNAL FUNCTIONS
@@ -268,10 +296,16 @@ async function loadInstruments(): Promise<void> {
       if (DEV_TUNING) console.log(`[AudioEngine] Attempting post-load reservations for ${store.robots.length} robots`);
       store.robots.forEach((robot: Robot) => {
         try {
-          const requestedType = robot.audioAttributes?.synthType as string | undefined;
           const waveform = robot.audioAttributes?.waveform as string | undefined;
           const adsr = robot.audioAttributes?.adsr as ADSREnvelope | undefined;
-          const ok = AudioEngine.reserveVoice(robot.id, requestedType ?? 'default', waveform, adsr);
+          const layered = (robot.audioAttributes as unknown as { visualAudioMap?: { layeredWave?: LayeredWave } })?.visualAudioMap?.layeredWave;
+          let ok = false;
+          if (layered) {
+            ok = AudioEngine.reserveVoice(robot.id, layered as LayeredWave);
+          } else {
+            const requestedType = robot.audioAttributes?.synthType as string | undefined;
+            ok = AudioEngine.reserveVoice(robot.id, requestedType ?? 'default', waveform, adsr);
+          }
           if (DEV_TUNING) console.log(`[AudioEngine] Post-load reserve for ${robot.id}: ${ok ? 'OK' : 'FAILED'}`);
         } catch (err) {
           if (DEV_TUNING) console.warn('[AudioEngine] Failed post-load reservation for robot', robot.id, err);
@@ -330,6 +364,21 @@ function updateAllPanners(_time?: number): void {
   } catch (err) {
     if (DEV_TUNING) console.warn('[AudioEngine] updateAllPanners failed', err);
   }
+
+  // Update composite voice panners as well
+  try {
+    for (const [robotId, entry] of compositeVoices.entries()) {
+      try {
+        const visualX = getRobotVisualX(robotId);
+        const panValue = calculatePanFromPosition(visualX);
+        entry.panner.pan.value = panValue;
+      } catch (err) {
+        if (DEV_TUNING) console.warn('[AudioEngine] Failed to update composite panner for', robotId, err);
+      }
+    }
+  } catch (err) {
+    if (DEV_TUNING) console.warn('[AudioEngine] update composite panners failed', err);
+  }
 }
 /**
  * Trigger note with polyphony cap enforcement.
@@ -360,17 +409,23 @@ export function triggerWithCap(params: NoteParams): boolean {
   activeVoices++;
 
   try {
-    // Select synth and corresponding panner from the pool
-    // Prefer reserved synth slot for this robot when present
+    // Select synth and corresponding panner from the pool or composite map
+    // Prefer reserved synth slot or composite voice for this robot when present
     const reserved = AudioEngine.getVoiceForRobot(robotId);
-    let synth: Tone.PolySynth | null;
-    let panner: Tone.Panner | null;
+    let synth: CompositeVoice | Tone.PolySynth | null = null;
+    let panner: Tone.Panner | null = null;
+    let usingComposite = false;
 
-    if (reserved) {
+    const reservation = reservedVoices.get(robotId);
+    if (reservation && reservation.type === 'composite') {
+      const comp = compositeVoices.get(robotId);
+      synth = comp?.composite ?? null;
+      panner = comp?.panner ?? null;
+      usingComposite = !!synth;
+    } else if (reserved) {
       synth = reserved;
       // Use stored type+index for O(1) panner lookup — avoids indexOf scan on every trigger.
       panner = null;
-      const reservation = reservedVoices.get(robotId);
       if (reservation && pannerPool) {
         panner = pannerPool[reservation.type]?.[reservation.index] ?? null;
       }
@@ -413,15 +468,15 @@ export function triggerWithCap(params: NoteParams): boolean {
       return false;
     }
 
-    // Only apply ADSR on reserved synths. Reserved voices should have their parameters set at reservation time
+    // Only apply ADSR on reserved synths/composites. Reserved voices should have their parameters set at reservation time
     // (reserveVoice()). Applying here is a safety measure.
-    if (adsr && reserved) {
+    if (adsr && (reserved || usingComposite)) {
       const maybeSetter = synth as unknown as { set?: (props: unknown) => void };
-      if (typeof maybeSetter.set === 'function') {
+      if (typeof maybeSetter?.set === 'function') {
         try {
           maybeSetter.set({ envelope: adsr });
         } catch (err) {
-          console.warn('[AudioEngine] Failed to apply ADSR to synth:', err);
+          console.warn('[AudioEngine] Failed to apply ADSR to synth/composite:', err);
         }
       }
     }
@@ -450,13 +505,16 @@ export function triggerWithCap(params: NoteParams): boolean {
         const visualX = getRobotVisualX(robotId);
         const panValue = calculatePanFromPosition(visualX);
         panner.pan.value = panValue;
-
       } catch (err) {
         console.warn('[AudioEngine] Failed to calculate/apply pan:', err);
       }
     }
 
-    synth.triggerAttackRelease(note, duration, scheduleTime, velocity ?? 0.8);
+    if (usingComposite && typeof synth?.triggerAttackRelease === 'function') {
+      synth.triggerAttackRelease(note, duration, scheduleTime, velocity ?? 0.8);
+    } else {
+      synth.triggerAttackRelease(note, duration, scheduleTime, velocity ?? 0.8);
+    }
     scheduleVoiceRelease(duration, scheduleTime);
 
     return true;
@@ -695,12 +753,70 @@ export const AudioEngine = {
    */
   reserveVoice(
     robotId: string,
-    synthType: string,
+    synthTypeOrLayered: string | LayeredWave,
     waveform?: string,
     adsr?: ADSREnvelope,
   ): boolean {
-    if (!synthPool || !reservedSlots) return false;
+    // Allow composite reservations even if the synth pool hasn't been created yet
+    if (!synthPool || !reservedSlots) {
+      if (!(typeof synthTypeOrLayered === 'object' && synthTypeOrLayered !== null && (synthTypeOrLayered as LayeredWave).base)) {
+        return false;
+      }
+    }
 
+    // If a layered descriptor was provided, create a composite voice routed into a per-robot sub-bus.
+    if (typeof synthTypeOrLayered === 'object' && synthTypeOrLayered !== null && (synthTypeOrLayered as LayeredWave).base) {
+      const descriptor = synthTypeOrLayered as LayeredWave;
+      try {
+        const composite = AudioEngine.createCompositeVoice(descriptor);
+
+        // Create per-robot bus: panner -> gain -> filter -> master compressor/destination
+        const PannerCtor = toneRecord.Panner as unknown as (new (...args: unknown[]) => unknown) | undefined;
+        const GainCtorLocal = toneRecord.Gain as unknown as (new (...args: unknown[]) => unknown) | undefined;
+        const FilterCtor = toneRecord.Filter as unknown as (new (...args: unknown[]) => unknown) | undefined;
+
+        const panner = typeof PannerCtor === 'function' ? new (PannerCtor as unknown as (new (...args: unknown[]) => Tone.Panner))({ pan: 0 }) as Tone.Panner : ({ connect: () => { }, pan: { value: 0 }, disconnect: () => { } } as MinimalToneNode) as unknown as Tone.Panner;
+        const busGain = typeof GainCtorLocal === 'function' ? new (GainCtorLocal as unknown as (new (...args: unknown[]) => Tone.Gain))(1) as Tone.Gain : ({ connect: () => ({}), disconnect: () => { }, gain: { value: 1 }, toDestination: () => { } } as MinimalToneNode) as unknown as Tone.Gain;
+        const busFilter = typeof FilterCtor === 'function' ? new (FilterCtor as unknown as (new (...args: unknown[]) => Tone.Filter))({ frequency: 1200, Q: 1 }) as Tone.Filter : ({ connect: () => ({}), disconnect: () => { }, toDestination: () => { } } as MinimalToneNode) as unknown as Tone.Filter;
+
+        // Connect graph: composite.output -> panner -> busGain -> busFilter -> master compressor/destination
+        try { composite.output.connect(panner); } catch (e) { if (DEV_TUNING) console.warn('[AudioEngine] composite.output.connect failed', e); }
+        try { (panner as unknown as { connect?: (target?: unknown) => unknown }).connect?.(busGain); } catch (e) { if (DEV_TUNING) console.warn('[AudioEngine] panner.connect failed', e); }
+        try { (busGain as unknown as { connect?: (target?: unknown) => unknown }).connect?.(busFilter); } catch (e) { if (DEV_TUNING) console.warn('[AudioEngine] busGain.connect failed', e); }
+        try {
+          if (_masterCompressor) {
+            (busFilter as unknown as { connect?: (target?: unknown) => unknown }).connect?.(_masterCompressor);
+          } else {
+            (busFilter as unknown as { toDestination?: () => unknown }).toDestination?.();
+          }
+        } catch (e) {
+          if (DEV_TUNING) console.warn('[AudioEngine] busFilter connection failed', e);
+        }
+
+        compositeVoices.set(robotId, { composite, panner, busGain, busFilter });
+        reservedVoices.set(robotId, { type: 'composite', index: -1, reservedAt: Date.now() });
+        if (DEV_TUNING) console.log(`[AudioEngine] Reserved composite voice for ${robotId}`);
+        return true;
+      } catch (err) {
+        if (DEV_TUNING) console.warn('[AudioEngine] Failed to create composite voice:', err);
+        // Fall back to a minimal, test-friendly composite stub so callers can reserve and trigger safely
+        const stubComposite = {
+          output: ({ connect: () => { } } as MinimalToneNode) as unknown as Tone.Gain,
+          triggerAttackRelease: (_note: string, _dur: NoteDuration | string, _time?: number, _vel?: number) => { },
+          set: (_params: unknown) => { },
+          dispose: () => { },
+        } as unknown as CompositeVoice;
+        const panner = ({ connect: () => { }, pan: { value: 0 }, disconnect: () => { } } as MinimalToneNode) as unknown as Tone.Panner;
+        const busGain = ({ connect: () => { }, disconnect: () => { }, gain: { value: 1 } } as MinimalToneNode) as unknown as Tone.Gain;
+        const busFilter = ({ connect: () => { }, disconnect: () => { }, toDestination: () => { } } as MinimalToneNode) as unknown as Tone.Filter;
+        compositeVoices.set(robotId, { composite: stubComposite, panner, busGain, busFilter });
+        reservedVoices.set(robotId, { type: 'composite', index: -1, reservedAt: Date.now() });
+        if (DEV_TUNING) console.log(`[AudioEngine] Reserved stub composite voice for ${robotId}`);
+        return true;
+      }
+    }
+
+    const synthType = synthTypeOrLayered as string;
     const requestedKey = (synthType || 'default').toString().toLowerCase();
     // Normalize requested synth type to pool keys used by loadInstruments()
     const typeKey = ((): string => {
@@ -727,6 +843,12 @@ export const AudioEngine = {
     let freeIndex = -1;
     let assignedType = typeKey;
 
+    // Guard: ensure reservedSlots is initialized before we index into it.
+    if (!reservedSlots) {
+      if (DEV_TUNING) console.warn('[AudioEngine] reserveVoice called before reservedSlots initialized');
+      return false;
+    }
+
     const requestedSlots = reservedSlots[typeKey];
     if (requestedSlots) {
       freeIndex = requestedSlots.findIndex((s) => s === null);
@@ -751,7 +873,7 @@ export const AudioEngine = {
     // Apply waveform and ADSR once on the now-dedicated, idle synth — safe because no
     // notes are in flight on this slot yet. Avoids mid-playback oscillator rebuilds and
     // eliminates redundant synth.set() calls on every note trigger.
-    const dedicatedSynth = synthPool[assignedType]?.[freeIndex];
+    const dedicatedSynth = synthPool && synthPool[assignedType]?.[freeIndex];
     const maybeSetter = dedicatedSynth as unknown as { set?: (props: unknown) => void } | undefined;
     if (maybeSetter && typeof maybeSetter.set === 'function') {
       if (waveform) {
@@ -779,6 +901,30 @@ export const AudioEngine = {
     if (!synthPool || !reservedSlots) return;
     const entry = reservedVoices.get(robotId);
     if (!entry) return;
+    // If this was a composite reservation, dispose composite and bus nodes
+    if (entry.type === 'composite') {
+      const comp = compositeVoices.get(robotId);
+      if (comp) {
+        try {
+          // call composite dispose to cleanup per-layer synths and internal nodes
+          try { comp.composite.dispose?.(); } catch (err) { if (DEV_TUNING) console.warn('[AudioEngine] composite.dispose failed', err); }
+          comp.panner.disconnect();
+          comp.busGain.disconnect();
+          comp.busFilter.disconnect();
+          // Tone nodes may implement dispose; call when available
+          try { comp.panner.dispose?.(); } catch { if (DEV_TUNING) console.warn('[AudioEngine] Failed disposing panner'); }
+          try { comp.busGain.dispose?.(); } catch { if (DEV_TUNING) console.warn('[AudioEngine] Failed disposing busGain'); }
+          try { comp.busFilter.dispose?.(); } catch { if (DEV_TUNING) console.warn('[AudioEngine] Failed disposing busFilter'); }
+        } catch (err) {
+          if (DEV_TUNING) console.warn('[AudioEngine] Failed to cleanup composite nodes', err);
+        }
+        compositeVoices.delete(robotId);
+      }
+      reservedVoices.delete(robotId);
+      if (DEV_TUNING) console.log(`[AudioEngine] Released composite voice for ${robotId}`);
+      return;
+    }
+
     const slots = reservedSlots[entry.type];
     if (!slots) {
       reservedVoices.delete(robotId);
@@ -790,13 +936,161 @@ export const AudioEngine = {
   },
 
   /** Return the synth instance reserved for a robot, or null if none. */
-  getVoiceForRobot(robotId?: string): Tone.PolySynth | null {
-    if (!synthPool || !reservedSlots || !robotId) return null;
+  getVoiceForRobot(robotId?: string): CompositeVoice | Tone.PolySynth | null {
+    if (!robotId) return null;
     const entry = reservedVoices.get(robotId);
     if (!entry) return null;
+    if (entry.type === 'composite') {
+      const comp = compositeVoices.get(robotId);
+      return comp?.composite ?? null;
+    }
+    if (!synthPool || !reservedSlots) return null;
     const pool = synthPool[entry.type];
     if (!pool || !pool[entry.index]) return null;
     return pool[entry.index];
+  },
+
+
+  /**
+   * Create a composite voice made of multiple layers (oscillators and optional noise).
+   * The returned object exposes an `output` node which the caller should connect
+   * into the global audio graph (panner/effects), plus `triggerAttackRelease` and `set`.
+   */
+  createCompositeVoice(descriptor: LayeredWave): CompositeVoice {
+    const GainCtor = toneRecord.Gain as unknown as (new (...args: unknown[]) => unknown) || undefined;
+    const OutGain = GainCtor ? new (GainCtor as unknown as (new (...args: unknown[]) => Tone.Gain))(1) : (() => {
+      // Minimal fallback gain node for test environments where Tone.Gain isn't mocked
+      const node: MinimalToneNode = {
+        gain: { value: 1 },
+        connect: function () { return node; },
+        disconnect: function () { },
+        toDestination: function () { },
+      };
+      return node as unknown as Tone.Gain;
+    })();
+    const out = OutGain as unknown as Tone.Gain;
+
+    const layers = descriptor.layers && descriptor.layers.length > 0
+      ? descriptor.layers
+      : [{ type: descriptor.base } as LayerDescriptor];
+
+    const layerNodes = layers.map((layer) => {
+      let synth: Tone.Synth | Tone.NoiseSynth | null;
+      let layerGain: Tone.Gain | null = null;
+      if (layer.type === 'noise') {
+        // Use NoiseSynth if available, otherwise fall back to Synth for tests
+        const NoiseCtor = toneRecord.NoiseSynth as unknown as (new (...args: unknown[]) => MinimalToneNode) | undefined;
+        const SynthCtor = toneRecord.Synth as unknown as (new (...args: unknown[]) => MinimalToneNode) | undefined;
+        const Noise = NoiseCtor ? new NoiseCtor({ volume: -12 }) : (SynthCtor ? new SynthCtor() : null);
+        layerGain = (typeof toneRecord.Gain === 'function') ? new (toneRecord.Gain as unknown as (new (...args: unknown[]) => Tone.Gain))(layer.gain ?? 1).connect(out) : (() => {
+          const node: MinimalToneNode = { gain: { value: layer.gain ?? 1 }, connect: function () { return node; } };
+          return node as unknown as Tone.Gain;
+        })();
+        if (Noise && typeof Noise.connect === 'function') Noise.connect(layerGain);
+        synth = Noise as unknown as Tone.Synth | Tone.NoiseSynth | null;
+      } else {
+        const s = new Tone.Synth({
+          oscillator: { type: layer.type as WaveformType },
+          envelope: {
+            attack: layer.adsr?.attack ?? 0.01,
+            decay: layer.adsr?.decay ?? 0.1,
+            sustain: layer.adsr?.sustain ?? 0.8,
+            release: layer.adsr?.release ?? 0.5,
+          },
+        });
+        layerGain = (typeof toneRecord.Gain === 'function') ? new (toneRecord.Gain as unknown as (new (...args: unknown[]) => Tone.Gain))(layer.gain ?? 1).connect(out) : (() => {
+          const node: MinimalToneNode = { gain: { value: layer.gain ?? 1 }, connect: function () { return node; } };
+          return node as unknown as Tone.Gain;
+        })();
+        if (layerGain && typeof s?.connect === 'function') s.connect(layerGain);
+        synth = s;
+      }
+      // apply detune if present and supported
+      try {
+        if (layer.detune !== undefined) {
+          try {
+            const osc = (synth as unknown as { oscillator?: { detune?: { value: number } } })?.oscillator;
+            if (osc && osc.detune) {
+              osc.detune.value = layer.detune;
+            }
+          } catch (err) {
+            if (DEV_TUNING) console.warn('[AudioEngine] Failed to apply detune on composite layer', err);
+          }
+        }
+      } catch (err) {
+        if (DEV_TUNING) console.warn('[AudioEngine] Failed to apply detune on composite layer', err);
+      }
+
+      return { synth, gainNode: layerGain, layer };
+    });
+
+    const triggerAttackRelease = (note: string, dur: NoteDuration | string, time?: number, velocity?: number) => {
+      // Fix: Avoid passing null as time to Tone.js (causes cancelAndHoldAtTime error)
+      const t = (typeof time === 'number' && isFinite(time)) ? time : Tone.now();
+      const durStr = String(dur);
+      layerNodes.forEach(({ synth }) => {
+        try {
+          if (synth && typeof (synth as unknown as { triggerAttackRelease?: unknown }).triggerAttackRelease === 'function') {
+            (synth as unknown as { triggerAttackRelease?: (n: string, d: string, time?: number, v?: number) => void }).triggerAttackRelease?.(note, durStr, t, velocity ?? 0.8);
+          } else if (synth && typeof (synth as unknown as { triggerAttack?: unknown }).triggerAttack === 'function') {
+            (synth as unknown as { triggerAttack?: (n: string, time?: number, v?: number) => void }).triggerAttack?.(note, t, velocity ?? 0.8);
+            const releaseAt = t + Tone.Time(durStr).toSeconds();
+            (synth as unknown as { triggerRelease?: (time?: number) => void }).triggerRelease?.(releaseAt + 0.01);
+          }
+        } catch (err) {
+          if (DEV_TUNING) console.warn('[AudioEngine] Composite layer trigger failed', err);
+        }
+      });
+    };
+
+    const set = (params: { layers?: Partial<LayerDescriptor>[]; outputGain?: number }) => {
+      if (params.outputGain !== undefined) out.gain.value = params.outputGain;
+      if (params.layers) {
+        params.layers.forEach((p) => {
+          layerNodes.forEach(({ synth, gainNode, layer }) => {
+            if (p.type === layer.type) {
+              if (p.gain !== undefined && gainNode) {
+                try {
+                  gainNode.gain.value = p.gain as number;
+                } catch (err) {
+                  if (DEV_TUNING) console.warn('[AudioEngine] Failed to set layer gain on composite', err);
+                }
+              }
+              if (p.detune !== undefined) {
+                try {
+                  const osc = (synth as unknown as { oscillator?: { detune?: { value: number } } })?.oscillator;
+                  if (osc && osc.detune) osc.detune.value = p.detune;
+                } catch (err) {
+                  if (DEV_TUNING) console.warn('[AudioEngine] Failed to set detune on composite layer', err);
+                }
+              }
+              if (p.adsr && typeof (synth as unknown as { set?: (props: unknown) => void }).set === 'function') {
+                try { (synth as unknown as { set?: (props: unknown) => void }).set?.({ envelope: p.adsr }); } catch (err) {
+                  if (DEV_TUNING) console.warn('[AudioEngine] Failed to set ADSR on composite layer', err);
+                }
+              }
+            }
+          });
+        });
+      }
+    };
+
+    const dispose = () => {
+      // Disconnect and dispose per-layer synths and gains
+      layerNodes.forEach(({ synth, gainNode }) => {
+        try {
+          try { (synth as unknown as { dispose?: () => void }).dispose?.(); } catch (err) { if (DEV_TUNING) console.warn('[AudioEngine] Error disposing composite layer synth', err); }
+        } catch (err) {
+          if (DEV_TUNING) console.warn('[AudioEngine] Error disposing composite layer synth', err);
+        }
+        try { gainNode?.disconnect(); } catch { if (DEV_TUNING) console.warn('[AudioEngine] Failed disconnecting gainNode'); }
+        try { (gainNode as unknown as { dispose?: () => void })?.dispose?.(); } catch { if (DEV_TUNING) console.warn('[AudioEngine] Failed disposing gainNode'); }
+      });
+      try { out.disconnect(); } catch { if (DEV_TUNING) console.warn('[AudioEngine] Failed disconnecting composite output'); }
+      try { (out as unknown as { dispose?: () => void })?.dispose?.(); } catch { if (DEV_TUNING) console.warn('[AudioEngine] Failed disposing composite output'); }
+    };
+
+    return { output: out, triggerAttackRelease, set, dispose };
   },
 
 

--- a/src/systems/spawnSystem.test.ts
+++ b/src/systems/spawnSystem.test.ts
@@ -112,6 +112,50 @@ describe('spawnSystem', () => {
       expect(uniqueSynthTypes.size).toBeGreaterThan(1);
       expect(uniqueAttacks.size).toBeGreaterThan(10); // Should have variety
     });
+
+    it('creates layeredWave with 1..3 layers and shapeParams in range', () => {
+      const attrs = generateAudioAttributes();
+      const vm = attrs.visualAudioMap;
+      expect(vm).toBeDefined();
+      expect(vm?.layeredWave).toBeDefined();
+      const layers = vm?.layeredWave?.layers ?? [];
+      expect(layers.length).toBeGreaterThanOrEqual(1);
+      expect(layers.length).toBeLessThanOrEqual(3);
+      // averagedADSR should be within ADSR_MAX-derived bounds
+      expect(vm?.averagedADSR).toBeDefined();
+      expect(vm?.averagedADSR?.attack).toBeGreaterThanOrEqual(0);
+      expect(vm?.averagedADSR?.decay).toBeGreaterThanOrEqual(0);
+      expect(vm?.averagedADSR?.sustain).toBeGreaterThanOrEqual(0);
+      expect(vm?.averagedADSR?.release).toBeGreaterThanOrEqual(0);
+      // shape params 0..1
+      expect(vm?.shapeParams?.scale).toBeGreaterThanOrEqual(0);
+      expect(vm?.shapeParams?.scale).toBeLessThanOrEqual(1);
+      expect(vm?.shapeParams?.roundness).toBeGreaterThanOrEqual(0);
+      expect(vm?.shapeParams?.roundness).toBeLessThanOrEqual(1);
+      expect(vm?.shapeParams?.detail).toBeGreaterThanOrEqual(0);
+      expect(vm?.shapeParams?.detail).toBeLessThanOrEqual(1);
+    });
+
+    it('averagedADSR equals single layer ADSR when only one layer (deterministic)', () => {
+      // Make Math.random deterministic to force single-layer and known values
+      const rnd = vi.spyOn(Math, 'random').mockImplementation(() => 0);
+      try {
+        const attrs = generateAudioAttributes();
+        const vm = attrs.visualAudioMap!;
+        const layers = vm.layeredWave?.layers ?? [];
+        // With Math.random=0 we should get exactly 1 layer
+        expect(layers.length).toBe(1);
+        const layerAdsr = layers[0].adsr!;
+        const avg = vm.averagedADSR!;
+        // The averaged should equal the single layer's values
+        expect(avg.attack).toBeCloseTo(layerAdsr.attack as number, 6);
+        expect(avg.decay).toBeCloseTo(layerAdsr.decay as number, 6);
+        expect(avg.sustain).toBeCloseTo(layerAdsr.sustain as number, 6);
+        expect(avg.release).toBeCloseTo(layerAdsr.release as number, 6);
+      } finally {
+        rnd.mockRestore();
+      }
+    });
   });
 
   describe('spawnRobot', () => {
@@ -194,9 +238,9 @@ describe('spawnSystem', () => {
       }));
       const { addRobot } = useOceanStore.getState();
       // seed store with max robots
-      addRobot({ id: 'a', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 1000 });
-      addRobot({ id: 'b', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 2000 });
-      addRobot({ id: 'c', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 3000 });
+      addRobot({ id: 'a', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', waveform: 'sine', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 1000, masterVolume: 0.7 });
+      addRobot({ id: 'b', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', waveform: 'sine', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 2000, masterVolume: 0.7 });
+      addRobot({ id: 'c', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', waveform: 'sine', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 3000, masterVolume: 0.7 });
       expect(useOceanStore.getState().robots.length).toBe(3);
 
       spawnRobot();
@@ -210,7 +254,7 @@ describe('spawnSystem', () => {
       // set max and min equal
       useOceanStore.setState({ settings: { bpm: 120, maxRobots: 1, minRobots: 1 } } as OceanStore);
       const { addRobot } = useOceanStore.getState();
-      addRobot({ id: 'only', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 123 });
+      addRobot({ id: 'only', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', waveform: 'sine', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 123, masterVolume: 0.7 });
 
       spawnRobot();
       expect(useOceanStore.getState().robots.length).toBe(1);

--- a/src/systems/spawnSystem.ts
+++ b/src/systems/spawnSystem.ts
@@ -6,6 +6,7 @@ import type { Robot, AudioAttributes, SynthType, WaveformType } from '../types/R
 import { RobotState } from '../types/Robot';
 import { generateMelodyForRobot } from '../engine/melodyGenerator';
 import { AudioEngine } from '../engine/AudioEngine';
+import type { LayeredWave, LayerDescriptor } from '../types/layeredAudio';
 import { scheduleRepeat, cancelSchedule } from '../engine/beatClock';
 import { DEV_TUNING } from '../constants';
 import { useOceanStore } from '../stores/oceanStore';
@@ -28,6 +29,10 @@ const ATTACK_RANGE = { min: 0.01, max: 0.5 };
 const DECAY_RANGE = { min: 0.1, max: 1.5 };
 const SUSTAIN_RANGE = { min: 0.3, max: 0.9 };
 const RELEASE_RANGE = { min: 0.2, max: 1.2 };
+
+// M7.4: Layered presets and normalization constants
+const MAX_LAYERS = 3;
+const ADSR_MAX = { attack: 2, decay: 2, sustain: 1, release: 5 };
 
 // Pitch ranges (Hz) - determines robot scale
 const PITCH_RANGES = [
@@ -165,7 +170,90 @@ export function generateAudioAttributes(): AudioAttributes {
   // Random waveform — evenly distributed (~25% each)
   const waveform = WAVEFORMS[Math.floor(Math.random() * WAVEFORMS.length)];
 
-  return { synthType, adsr, pitchRange, filterFreq, reverb, waveform };
+  // Derive a compact visualAudioMap to store on the robot at spawn time.
+  // ---
+  // M7.4: Generate layered presets (1..MAX_LAYERS layers), each with gain and ADSR.
+  // The mapping and normalization logic below is critical for visual/audio consistency:
+  // - Each layer gets randomized ADSR and gain.
+  // - Gain-weighted averaging and normalization (by ADSR_MAX) is used to produce a single averaged ADSR.
+  // - These normalized values are mapped to ShapeParams for visuals.
+  // If you change the mapping, update docs and robotVisualMapper accordingly.
+  const clamp = (v: number) => Math.max(0, Math.min(1, v));
+
+  const numLayers = 1 + Math.floor(Math.random() * MAX_LAYERS); // 1..MAX_LAYERS
+  const layers: LayeredWave['layers'] = [];
+  for (let i = 0; i < numLayers; i++) {
+    const isNoise = Math.random() < 0.18; // small chance of noise layer
+    const layerWave: LayerDescriptor = {
+      type: isNoise ? 'noise' : WAVEFORMS[Math.floor(Math.random() * WAVEFORMS.length)],
+      gain: 0.2 + Math.random() * 1.0, // 0.2 .. 1.2
+      detune: (Math.random() - 0.5) * 4, // -20 .. +20 cents
+      adsr: {
+        attack: ATTACK_RANGE.min + Math.random() * (ATTACK_RANGE.max - ATTACK_RANGE.min),
+        decay: DECAY_RANGE.min + Math.random() * (DECAY_RANGE.max - DECAY_RANGE.min),
+        sustain: SUSTAIN_RANGE.min + Math.random() * (SUSTAIN_RANGE.max - SUSTAIN_RANGE.min),
+        release: RELEASE_RANGE.min + Math.random() * (RELEASE_RANGE.max - RELEASE_RANGE.min),
+      },
+    };
+    layers.push(layerWave);
+  }
+
+  // Compute gain-weighted normalized ADSR (normalize by ADSR_MAX), then convert back
+  // to seconds for averagedADSR while keeping a normalized copy for mapping.
+  // ---
+  // This ensures that the visual mapping (scale, roundness, detail) is always in 0..1 range
+  // and reflects the actual audio envelope shape.
+  let totalGain = 0;
+  for (const l of layers) totalGain += l.gain ?? 1;
+  if (totalGain <= 0) totalGain = layers.length || 1;
+
+  const normSum = layers.reduce(
+    (acc, l) => {
+      const g = l.gain ?? 1;
+      acc.attack += (l.adsr?.attack ?? 0) / ADSR_MAX.attack * g;
+      acc.decay += (l.adsr?.decay ?? 0) / ADSR_MAX.decay * g;
+      acc.sustain += (l.adsr?.sustain ?? 0) / ADSR_MAX.sustain * g;
+      acc.release += (l.adsr?.release ?? 0) / ADSR_MAX.release * g;
+      return acc;
+    },
+    { attack: 0, decay: 0, sustain: 0, release: 0 }
+  );
+
+  const averagedNorm = {
+    attack: normSum.attack / totalGain,
+    decay: normSum.decay / totalGain,
+    sustain: normSum.sustain / totalGain,
+    release: normSum.release / totalGain,
+  };
+
+  const averagedADSR = {
+    attack: averagedNorm.attack * ADSR_MAX.attack,
+    decay: averagedNorm.decay * ADSR_MAX.decay,
+    sustain: averagedNorm.sustain * ADSR_MAX.sustain,
+    release: averagedNorm.release * ADSR_MAX.release,
+  };
+
+  const averagedGain = (layers.reduce((s, l) => s + (l.gain ?? 1), 0) / layers.length) || 1;
+
+  // Map averaged normalized ADSR into simple ShapeParams (0..1)
+  // Mapping rules:
+  //   - scale: larger when attack is shorter (snappier envelope → bigger robot)
+  //   - roundness: mapped from sustain (higher sustain → rounder shape)
+  //   - detail: mapped from release (longer release → more detail/greebles)
+  // If you adjust these, update robotVisualMapper and docs for consistency.
+  const scale = clamp(0.25 + (1 - averagedNorm.attack) * 0.75);
+  const roundness = clamp(averagedNorm.sustain);
+  const detail = clamp(averagedNorm.release);
+
+  const visualAudioMap = {
+    layeredWave: { base: waveform, layers },
+    averagedADSR,
+    averagedGain,
+    shapeParams: { scale, roundness, detail },
+    layerVisuals: layers.map((l) => ({ color: undefined, scale: clamp((l.gain ?? 1) / 1.2,), offset: { x: 0, y: 0 } })),
+  };
+
+  return { synthType, adsr, pitchRange, filterFreq, reverb, waveform, visualAudioMap };
 }
 
 /**
@@ -237,12 +325,17 @@ export function spawnRobot(): void {
   // Reserve a voice for this robot (best-effort) so its timbre/adsr are isolated.
   // Waveform is applied once here on the idle slot — no mid-playback oscillator rebuilds.
   try {
-    AudioEngine.reserveVoice(
-      robot.id,
-      robot.audioAttributes.synthType as string,
-      robot.audioAttributes.waveform,
-      robot.audioAttributes.adsr,
-    );
+    const layered = (robot.audioAttributes as unknown as { visualAudioMap?: { layeredWave?: LayeredWave } })?.visualAudioMap?.layeredWave as LayeredWave | undefined;
+    if (layered) {
+      AudioEngine.reserveVoice(robot.id, layered);
+    } else {
+      AudioEngine.reserveVoice(
+        robot.id,
+        robot.audioAttributes.synthType as string,
+        robot.audioAttributes.waveform,
+        robot.audioAttributes.adsr,
+      );
+    }
   } catch (err) {
     if (DEV_TUNING) console.warn('[SpawnSystem] reserveVoice failed', err);
   }

--- a/src/types/Robot.ts
+++ b/src/types/Robot.ts
@@ -1,4 +1,5 @@
 import type { Vec2 } from './Vec2';
+import type { VisualAudioMap } from './layeredAudio';
 
 /**
  * Note duration values for Tone.js scheduling
@@ -56,6 +57,8 @@ export interface AudioAttributes {
   filterFreq: number;  // Hz (cutoff frequency, 0 = no filter)
   reverb: number;      // 0-1 (mix amount)
   waveform: WaveformType; // Oscillator shape applied once at voice reservation time
+  /** Optional compact visual/audio mapping produced at spawn time and stored on the robot */
+  visualAudioMap?: VisualAudioMap;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,5 @@
+export * from './Actor';
+export * from './Factory';
+export * from './layeredAudio';
+export * from './Robot';
+export * from './Vec2';

--- a/src/types/layeredAudio.ts
+++ b/src/types/layeredAudio.ts
@@ -1,0 +1,47 @@
+import type { WaveformType, ADSREnvelope } from './Robot'
+
+/** Raw ADSR values used on individual layers (may be partial at spawn time) */
+export interface ADSTRaw {
+  attack?: number
+  decay?: number
+  sustain?: number
+  release?: number
+}
+
+/** Descriptor for a single layer within a layered wave */
+export interface LayerDescriptor {
+  type: WaveformType | 'noise'
+  gain?: number
+  detune?: number // cents
+  adsr?: ADSTRaw
+}
+
+/** Compact layered wave descriptor stored on spawn */
+export interface LayeredWave {
+  base: WaveformType
+  layers?: LayerDescriptor[]
+}
+
+/** Small set of shape parameters derived from averaged audio values */
+export interface ShapeParams {
+  scale: number // 0..1
+  roundness: number // 0..1
+  detail: number // 0..1
+}
+
+/** Visual properties for an individual audio layer (spawn-time, serializable) */
+export interface LayerVisual {
+  color?: string
+  scale?: number // 0..1
+  offset?: { x: number; y: number }
+}
+
+/** Visual mapping derived from audio for spawn-time storage on robots */
+export interface VisualAudioMap {
+  layeredWave?: LayeredWave
+  averagedADSR?: ADSREnvelope
+  averagedGain?: number
+  shapeParams?: ShapeParams
+  layerVisuals?: LayerVisual[]
+}
+


### PR DESCRIPTION
…ices

Add LayeredWave, LayerDescriptor, ShapeParams, and VisualAudioMap types for layered audio and spawn-time visual mapping Update spawnSystem to generate layered audio presets and normalized, gain-weighted averaged ADSR for each robot Store a serializable visualAudioMap on each robot's audio attributes for deterministic visual rendering Implement composite voice factory in AudioEngine to support multi-layered synths per robot, routed through per-robot sub-bus Extend reserveVoice to accept layered descriptors and manage composite voices Add robotVisualMapper to convert visualAudioMap into component-friendly props for body shape, greebles, and lights Update robot body components to use mapped visual props and support spawn-time audio-driven visuals Add AudioVisualInspector debug UI for previewing layered audio/visual mapping and body variants Add unit tests for layered audio, visual mapping, and composite voice behavior Update documentation with mapping rules, spawn-time normalization, and usage examples Closes #166

