### PR TITLE
feat(types): add GlobalAudioSettings type

### DIFF
--- a/src/types/globalAudio.ts
+++ b/src/types/globalAudio.ts
@@ -1,0 +1,98 @@
+/**
+ * Global audio settings types.
+ * All fields are JSON-serializable primitives suitable for Zustand storage.
+ */
+
+export interface ReverbSettings {
+  enabled: boolean;
+  /** seconds (0.1 - 10) */
+  decay: number;
+  /** seconds (0 - 0.5) */
+  preDelay: number;
+  /** Hz (100 - 8000) */
+  dampening: number;
+  /** 0 - 1 */
+  wet: number;
+}
+
+export interface DelaySettings {
+  enabled: boolean;
+  /** seconds (0 - 1) */
+  delayTime: number;
+  /** 0 - 0.95 */
+  feedback: number;
+  /** 0 - 1 */
+  wet: number;
+}
+
+export interface CompressorSettings {
+  enabled: boolean;
+  /** dB (-60 - 0) */
+  threshold: number;
+  /** 1 - 20 */
+  ratio: number;
+  /** seconds (0.001 - 1) */
+  attack: number;
+  /** seconds (0.01 - 1) */
+  release: number;
+  /** dB (0 - 40) */
+  knee: number;
+}
+
+export interface EQ3Settings {
+  enabled: boolean;
+  /** dB (-12 - 12) */
+  low: number;
+  /** dB (-12 - 12) */
+  mid: number;
+  /** dB (-12 - 12) */
+  high: number;
+}
+
+export type FilterType = 'lowpass' | 'highpass';
+
+export interface FilterSettings {
+  enabled: boolean;
+  type: FilterType;
+  /** Hz (20 - 20000) */
+  frequency: number;
+  /** Q (0.1 - 20) */
+  Q: number;
+}
+
+export interface ChorusSettings {
+  enabled: boolean;
+  /** Hz (0.1 - 10) */
+  rate: number;
+  /** 0 - 1 */
+  depth: number;
+  /** ms (2 - 20) */
+  delayTime: number;
+  /** 0 - 1 */
+  feedback: number;
+  /** 0 - 1 */
+  wet: number;
+}
+
+/**
+ * Top-level global audio settings: single source of truth for FX state.
+ */
+export interface GlobalAudioSettings {
+  globalBypass: boolean;
+  reverb: ReverbSettings;
+  delay: DelaySettings;
+  compressor: CompressorSettings;
+  eq3: EQ3Settings;
+  filter: FilterSettings;
+  chorus: ChorusSettings;
+}
+
+export const DEFAULT_GLOBAL_AUDIO_SETTINGS: GlobalAudioSettings = {
+  globalBypass: false,
+  reverb: { enabled: true, decay: 1.5, preDelay: 0.02, dampening: 3000, wet: 0.3 },
+  delay: { enabled: false, delayTime: 0.25, feedback: 0.2, wet: 0.15 },
+  compressor: { enabled: false, threshold: -24, ratio: 2, attack: 0.003, release: 0.25, knee: 6 },
+  eq3: { enabled: false, low: 0, mid: 0, high: 0 },
+  filter: { enabled: false, type: 'lowpass', frequency: 20000, Q: 1 },
+  chorus: { enabled: false, rate: 1.5, depth: 0.2, delayTime: 12, feedback: 0.1, wet: 0.2 },
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 export * from './Actor';
-export * from './Factory';
 export * from './layeredAudio';
 export * from './Robot';
 export * from './Vec2';
+export * from './globalAudio';


### PR DESCRIPTION
Add serializable TypeScript interfaces for global FX parameters and a DEFAULT_GLOBAL_AUDIO_SETTINGS constant to provide defaults. Expose GlobalAudioSettings via the types index so the app can import a single source-of-truth for FX state stored in Zustand.

Closes #168