### PR TITLE
refactor(types): remove reverb from Robot audio attrs

### DIFF
--- a/src/systems/spawnSystem.test.ts
+++ b/src/systems/spawnSystem.test.ts
@@ -98,12 +98,6 @@ describe('spawnSystem', () => {
       expect(attrs.filterFreq).toBeLessThanOrEqual(2500);
     });
 
-    it('generates reverb amount between 0 and 1', () => {
-      const attrs = generateAudioAttributes();
-      expect(attrs.reverb).toBeGreaterThanOrEqual(0);
-      expect(attrs.reverb).toBeLessThanOrEqual(1);
-    });
-
     it('generates varied attributes (not all the same)', () => {
       const attributes = Array.from({ length: 20 }, () => generateAudioAttributes());
       const uniqueSynthTypes = new Set(attributes.map((a) => a.synthType));
@@ -238,9 +232,9 @@ describe('spawnSystem', () => {
       }));
       const { addRobot } = useOceanStore.getState();
       // seed store with max robots
-      addRobot({ id: 'a', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', waveform: 'sine', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 1000, masterVolume: 0.7 });
-      addRobot({ id: 'b', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', waveform: 'sine', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 2000, masterVolume: 0.7 });
-      addRobot({ id: 'c', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', waveform: 'sine', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 3000, masterVolume: 0.7 });
+      addRobot({ id: 'a', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', waveform: 'sine', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0 }, octaveRange: [3, 4], createdAt: 1000, masterVolume: 0.7 });
+      addRobot({ id: 'b', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', waveform: 'sine', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0 }, octaveRange: [3, 4], createdAt: 2000, masterVolume: 0.7 });
+      addRobot({ id: 'c', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', waveform: 'sine', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0 }, octaveRange: [3, 4], createdAt: 3000, masterVolume: 0.7 });
       expect(useOceanStore.getState().robots.length).toBe(3);
 
       spawnRobot();

--- a/src/systems/spawnSystem.ts
+++ b/src/systems/spawnSystem.ts
@@ -174,8 +174,6 @@ export function generateAudioAttributes(): AudioAttributes {
     FILTER_FREQ_RANGE.min +
     Math.random() * (FILTER_FREQ_RANGE.max - FILTER_FREQ_RANGE.min);
 
-  // Random reverb amount
-  const reverb = Math.random();
 
   // Random waveform — evenly distributed (~25% each)
   const waveform = WAVEFORMS[Math.floor(Math.random() * WAVEFORMS.length)];
@@ -268,7 +266,7 @@ export function generateAudioAttributes(): AudioAttributes {
   // Detune: default 0 cents (fine pitch adjustment)
   const detune = 0;
 
-  return { synthType, adsr, pitchRange, filterFreq, reverb, waveform, visualAudioMap, phase, detune };
+  return { synthType, adsr, pitchRange, filterFreq, waveform, visualAudioMap, phase, detune };
 }
 
 /**

--- a/src/types/Robot.ts
+++ b/src/types/Robot.ts
@@ -55,7 +55,6 @@ export interface AudioAttributes {
     max: number;       // Hz
   };
   filterFreq: number;  // Hz (cutoff frequency, 0 = no filter)
-  reverb: number;      // 0-1 (mix amount)
   waveform: WaveformType; // Oscillator shape applied once at voice reservation time
   /** Phase in degrees (0..360) applied to oscillator at reservation time */
   phase?: number;


### PR DESCRIPTION
- Remove the unused 
everb field from the AudioAttributes type.
- Stop generating/returning 
everb in spawnSystem so robots no longer carry per-robot reverb.
- Keeps global reverb via GlobalAudioSettings as single source of truth.

Closes #173

