### PR TITLE
feat(state): add dayLengthMeasures & setDayLength

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { AudioStatus } from './components/debug/AudioStatus';
 import { spawnRobot } from './systems/spawnSystem';
 import { useOceanStore } from './stores/oceanStore';
 import { subscribeToMeasure } from './engine/beatClock';
+import { DAY_CYCLE_MEASURES } from './utils/lightingUtils';
 import { DEV_TUNING } from './constants';
 
 function App() {
@@ -13,13 +14,16 @@ function App() {
 
   // Wire the BeatClock measure tick → store so factories can react to day/night
   const handleAudioReady = () => {
-    // Keep world time when Play is clicked: add transport measure to the
+    // Keep world time when Play is clicked: map the transport's 96-measure
+    // beat clock into the configured world day length and add the
     // pre-existing world measure so audio starts at 0 while the world keeps
     // its loaded time-of-day.
     const initialWorldMeasure = useOceanStore.getState().currentMeasure;
-    subscribeToMeasure((m) =>
-      useOceanStore.getState().setCurrentMeasure((initialWorldMeasure + m) % 96)
-    );
+    subscribeToMeasure((m) => {
+      const dayLength = useOceanStore.getState().settings.dayLengthMeasures || 96;
+      const scaled = Math.floor((m / DAY_CYCLE_MEASURES) * dayLength);
+      useOceanStore.getState().setCurrentMeasure((initialWorldMeasure + scaled) % dayLength);
+    });
     setAudioReady(true);
   };
 

--- a/src/components/actors/Factory.tsx
+++ b/src/components/actors/Factory.tsx
@@ -5,7 +5,7 @@ import { selectVariantFromSeed, VARIANT_CONF } from './factoryVariants';
 import { getRowConfig } from '../../systems/factoryPlacementSystem';
 import { calcSilhouetteSize, bottomAnchorTransform } from './silhouetteUtils';
 import { applyColorShift, shiftHSL, clamp } from '../../utils/colorUtils';
-import { getLighting, getNightDepth, FLICKER_PERIOD, FILL_TRANSITION } from '../../utils/lightingUtils';
+import { getLighting, getNightDepth, FLICKER_PERIOD, FILL_TRANSITION, DAY_CYCLE_MEASURES } from '../../utils/lightingUtils';
 import { ROOFTOP_RENDERERS } from './greebles/rooftopGreebles';
 import { FACADE_RENDERERS } from './greebles/facadeGreebles';
 import type { GreebleRendererContext } from './greebles/greebleTypes';
@@ -88,11 +88,16 @@ const FactoryInner: React.FC<FactoryProps> = ({ actor }) => {
   // Resolve east/west lightness multipliers:
   // debug preset overrides the live cycle (useful for visual testing).
   //
-  // lightMeasure: quantised to multiples of 4 so body fills only update once
-  // every 4 measures — the 96-measure day cycle changes slowly enough that
-  // sub-4-measure granularity is imperceptible.
+  // lightMeasure: quantised to multiples of an in-world hour so body fills
+  // update once per in-world hour. For a 96-measure day this equals 4 measures
+  // (96/24). Using `dayLengthMeasures` keeps building lighting proportional
+  // when the day length is changed.
   const bpm = useOceanStore(state => state.settings.bpm);
-  const lightMeasure = useOceanStore(state => Math.round(state.currentMeasure / 4) * 4);
+  const lightMeasure = useOceanStore(state => {
+    const dayLength = state.settings.dayLengthMeasures || 96;
+    const measuresPerHour = Math.max(1, Math.round(dayLength / 24));
+    return Math.round(state.currentMeasure / measuresPerHour) * measuresPerHour;
+  });
   // flickerEpoch: phased per building so window rerolls are spread across
   // FLICKER_PERIOD consecutive measures rather than all firing at once.
   const flickerEpoch = useOceanStore(state =>
@@ -100,9 +105,22 @@ const FactoryInner: React.FC<FactoryProps> = ({ actor }) => {
   );
 
   const preset = DEBUG_LIGHTING_PRESET ? LIGHTING_PRESETS[DEBUG_LIGHTING_PRESET] : null;
-  const { eastL: eastLMultiplier, westL: westLMultiplier } = preset
-    ? { eastL: preset.east, westL: preset.west }
-    : getLighting(lightMeasure);
+
+  // Map the quantised `lightMeasure` (0..dayLength-1) into the 0..95 cycle
+  // expected by `getLighting`. This keeps the relative sun position correct
+  // even when `dayLengthMeasures` is changed from the default 96.
+  const eastLMultiplier = (() => {
+    if (preset) return preset.east;
+    const dayLength = useOceanStore.getState().settings.dayLengthMeasures || 96;
+    const cycleMeasure = Math.round((lightMeasure / dayLength) * DAY_CYCLE_MEASURES) % DAY_CYCLE_MEASURES;
+    return getLighting(cycleMeasure).eastL;
+  })();
+  const westLMultiplier = (() => {
+    if (preset) return preset.west;
+    const dayLength = useOceanStore.getState().settings.dayLengthMeasures || 96;
+    const cycleMeasure = Math.round((lightMeasure / dayLength) * DAY_CYCLE_MEASURES) % DAY_CYCLE_MEASURES;
+    return getLighting(cycleMeasure).westL;
+  })();
 
   const nightDepth = getNightDepth(eastLMultiplier, westLMultiplier);
   /** Average used for elements spanning the full roof width */

--- a/src/stores/oceanStore.ts
+++ b/src/stores/oceanStore.ts
@@ -21,6 +21,8 @@ export interface OceanStore {
     bpm: number;
     maxRobots: number;
     minRobots: number; // lower bound for population bouncing
+    /** Number of measures that make up a full day (default 96) */
+    dayLengthMeasures: number;
   };
   /** Current hour derived from currentMeasure (0..23) */
   currentHour: number;
@@ -39,15 +41,18 @@ export interface OceanStore {
   /** Current measure in the 96-measure day/night cycle (0–95). */
   currentMeasure: number;
   setCurrentMeasure: (measure: number) => void;
+  /** Update the configured day length (in measures) */
+  setDayLength: (measures: number) => void;
 }
 
 // ========================================
 // CONSTANTS
 // ========================================
 const INITIAL_SETTINGS = {
-  bpm: 120,
+  bpm: 240,
   maxRobots: 12,
   minRobots: 2,
+  dayLengthMeasures: 96,
 };
 
 // ========================================
@@ -59,14 +64,18 @@ export const useOceanStore = create<OceanStore>((_set, get) => ({
   selectedRobotId: null,
   totalInteractions: 0,
   settings: { ...INITIAL_SETTINGS },
-  // Start world at measure 1200 (wrapped into 0..95 range => 1200 % 96 = 48)
-  currentMeasure: 48,
-  // Derived from wrapped measure: hour = floor(48 / 4) = 12 (noon)
-  currentHour: 12,
+  // Start world at measure 1200 wrapped into configured day length
+  currentMeasure: (() => 1200 % INITIAL_SETTINGS.dayLengthMeasures)(),
+  // Derived from wrapped measure using configured day length
+  currentHour: (() => {
+    const m = 1200 % INITIAL_SETTINGS.dayLengthMeasures;
+    return Math.floor(m / (INITIAL_SETTINGS.dayLengthMeasures / 24));
+  })(),
   // Compute initial lightness to match setCurrentMeasure behaviour so visuals
   // reflect the loaded time immediately.
   lightnessMultiplier: (() => {
-    const hour = 12;
+    const m = 1200 % INITIAL_SETTINGS.dayLengthMeasures;
+    const hour = Math.floor(m / (INITIAL_SETTINGS.dayLengthMeasures / 24));
     const angle = (hour / 24) * 2 * Math.PI - Math.PI / 2;
     return 0.7 + 0.3 * Math.sin(angle);
   })(),
@@ -141,10 +150,11 @@ export const useOceanStore = create<OceanStore>((_set, get) => ({
   },
 
   setCurrentMeasure: (measure) => {
-    const m = measure % 96;
+    const dayLength = get().settings.dayLengthMeasures;
+    const m = measure % dayLength;
 
-    // Derive hour (0..23) from 96-measure cycle (4 measures = 1 hour)
-    const hour = Math.floor((m % 96) / 4);
+    // Derive hour (0..23) from configured day-length (dayLength / 24 measures = 1 hour)
+    const hour = Math.floor(m / (dayLength / 24));
 
     // Smooth sinusoidal lightness mapping with anchor points:
     // hour 0 -> 0.4, 6 -> 0.7, 12 -> 1.0, 18 -> 0.7, 23 -> 0.4
@@ -153,6 +163,11 @@ export const useOceanStore = create<OceanStore>((_set, get) => ({
     const lightnessMultiplier = 0.7 + 0.3 * Math.sin(angle);
 
     _set({ currentMeasure: m, currentHour: hour, lightnessMultiplier });
+  },
+
+  setDayLength: (measures) => {
+    const sanitized = Math.max(1, Math.floor(measures));
+    _set((state) => ({ settings: { ...state.settings, dayLengthMeasures: sanitized } }));
   },
 }));
 

--- a/src/systems/factorySystem.ts
+++ b/src/systems/factorySystem.ts
@@ -14,6 +14,9 @@ import { DEV_TUNING } from '../constants';
 // ========================================
 // CONSTANTS
 // ========================================
+// ========================================
+// CONSTANTS
+// ========================================
 const PRODUCTION_INTERVAL = 60;  // 60 measures (15 "hours")
 
 // ========================================
@@ -117,6 +120,9 @@ export function createRobotFromFactory(factory: Actor): Robot {
     direction: 'right',
     melody: generateMelodyForRobot(),
     audioAttributes: generateAudioAttributes(),
+    // sensible defaults for required audio/visual ranges
+    octaveRange: [3, 5],
+    masterVolume: 0.9,
     createdAt: Date.now(),
   };
 }

--- a/src/systems/spawnSystem.test.ts
+++ b/src/systems/spawnSystem.test.ts
@@ -248,7 +248,7 @@ describe('spawnSystem', () => {
       // set max and min equal
       useOceanStore.setState({ settings: { bpm: 120, maxRobots: 1, minRobots: 1 } } as OceanStore);
       const { addRobot } = useOceanStore.getState();
-      addRobot({ id: 'only', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', waveform: 'sine', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0, reverb: 0 }, octaveRange: [3, 4], createdAt: 123, masterVolume: 0.7 });
+      addRobot({ id: 'only', state: RobotState.Idle, direction: 'right', position: { x: 0, y: 0 }, destination: null, melody: [], audioAttributes: { synthType: 'AMSynth', waveform: 'sine', adsr: { attack: 0, decay: 0, sustain: 0, release: 0 }, pitchRange: { min: 0, max: 0 }, filterFreq: 0 }, octaveRange: [3, 4], createdAt: 123, masterVolume: 0.7 });
 
       spawnRobot();
       expect(useOceanStore.getState().robots.length).toBe(1);


### PR DESCRIPTION
Add dayLengthMeasures to oceanStore.settings (default 96) and a setDayLength(measures) action.
Make setCurrentMeasure and initial currentHour derive from the configured day length instead of a hardcoded 96-measure cycle. Scale the BeatClock→store mapping in App.tsx so transport ticks are mapped proportionally into the configured day length. Update Factory lighting to quantize by in-world hour computed from dayLengthMeasures and map that into the 0–95 lighting cycle used by getLighting, keeping visuals proportional for short/long days. Add sensible octaveRange and masterVolume defaults for robots spawned from factories and update a test to match the new audio attributes shape.
Closes #174

