### PR TITLE
fix(components): pad measure, use design tokens

### DIFF
--- a/src/components/ui/TransportBar.css
+++ b/src/components/ui/TransportBar.css
@@ -2,13 +2,13 @@
   position: sticky;
   top: 0;
   width: 100%;
-  height: var(--transport-height, 48px);
-  min-height: 48px;
+  height: var(--transport-height);
+  min-height: var(--transport-height);
   z-index: var(--z-header);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 var(--spacing-md, 12px);
+  padding: 0 var(--spacing-md);
   box-sizing: border-box;
   background: var(--color-surface);
   border-bottom: var(--border-width) solid var(--border-color);
@@ -20,15 +20,15 @@
 .transport-bar__buttons {
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm, 8px);
+  gap: var(--spacing-sm);
 }
 
 .transport-bar__btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 44px;
-  min-height: 44px;
+  min-width: var(--touch-target-size);
+  min-height: var(--touch-target-size);
   padding: 0;
   border: var(--border-width) solid var(--border-color);
   border-radius: var(--border-radius);
@@ -65,7 +65,7 @@
 .transport-bar__displays {
   display: flex;
   align-items: center;
-  gap: var(--spacing-md, 12px);
+  gap: var(--spacing-md);
 }
 
 .transport-bar__measure,
@@ -85,9 +85,9 @@
    Separator (Radix Toolbar.Separator)
    ---------------------------------------- */
 .transport-bar__separator {
-  width: var(--border-width, 1px);
-  height: 24px;
+  width: var(--border-width);
+  height: var(--transport-separator-height);
   background: var(--border-color);
-  margin: 0 var(--spacing-sm, 8px);
+  margin: 0 var(--spacing-sm);
   flex-shrink: 0;
 }

--- a/src/components/ui/TransportBar.tsx
+++ b/src/components/ui/TransportBar.tsx
@@ -18,7 +18,8 @@ export function TransportBar() {
   const currentMeasure = useOceanStore((s) => s.currentMeasure);
   const bpm = useAudioStore((s) => s.bpm);
 
-  const measureLabel = isPoweredOn ? `M: ${currentMeasure}` : 'M: ---';
+  const padMeasure = (m: number) => String(m).padStart(3, '0');
+  const measureLabel = isPoweredOn ? `M: ${padMeasure(currentMeasure)}` : 'M: ---';
 
   return (
     <Toolbar.Root className="transport-bar" aria-label="Transport controls">

--- a/src/stores/oceanStore.ts
+++ b/src/stores/oceanStore.ts
@@ -70,8 +70,8 @@ export const useOceanStore = create<OceanStore>((_set, get) => ({
   selectedRobotId: null,
   totalInteractions: 0,
   settings: { ...INITIAL_SETTINGS },
-  // Start world at an arbitrary measure (no wrapping for time-of-day)
-  currentMeasure: (() => 1200)(),
+  // Start world at measure 0 so initial displays are in-range
+  currentMeasure: 0,
   // Time-of-day is driven by wall clock. On load the day starts now, so
   // currentHour should be approximately 0.
   dayStartTimestamp: Date.now(),


### PR DESCRIPTION
Pad transport measure display to three digits (e.g. M: 048) in TransportBar.tsx to match the spec and avoid raw
numbers appearing.
Replace hardcoded CSS fallbacks with design tokens in TransportBar.css (--transport-height,
--touch-target-size, --transport-separator-height) so the transport bar relies on global tokens (Issue 1 should add the token definitions).
Set initial currentMeasure to 0 in oceanStore.ts to prevent out-of-range displays on load.
