### PR TITLE
feat(ui): build RobotList panel with robot selection

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,7 +4,32 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: var(--color-background);
+}
+
+.real-world::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(45deg, transparent 50%, #1e1e1e 75%, #083a70 75%, #1d5da1);
+
+  pointer-events: none;
+  z-index: -1;
+}
+
+.real-world::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #1e1e1e 25%, #1d5da1 25%, #083a70 50%, #1e1e1e 50%, #1e1e1e 75%, #1d5da1 75%, #083a70);
+
+  pointer-events: none;
+  z-index: -2;
 }
 
 /* Vite default demo styles removed — layout tokens live in src/index.css */

--- a/src/components/panels/physical/ScreenViewport.css
+++ b/src/components/panels/physical/ScreenViewport.css
@@ -2,7 +2,52 @@
   position: relative;
   flex: 1 1 auto;
   overflow: hidden;
-  background: var(--color-bg);
+}
+
+.screen-viewport::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  --direction: to right;
+  /* Default direction for stripes, can be overridden for horizontal stripes */
+  background-image: linear-gradient(var(--direction),
+      rgba(0, 255, 255, 0) 0%,
+      rgba(0, 255, 255, 0.05) 9%,
+      rgba(255, 255, 255, 0.1) 10%,
+      rgba(0, 255, 255, 0.05) 11%,
+      rgba(0, 255, 255, 0) 25%,
+      rgba(0, 255, 255, 0.1) 49%,
+      rgba(255, 255, 255, 0.3) 50%,
+      rgba(0, 255, 255, 0.1) 51%,
+      rgba(0, 255, 255, 0) 75%,
+      rgba(0, 255, 255, 0.05) 89%,
+      rgba(255, 255, 255, 0.1) 90%,
+      rgba(0, 255, 255, 0.05) 91%,
+      rgba(0, 255, 255, 0) 100%);
+  box-shadow: 0 0 20px rgba(0, 255, 255, 0.2);
+  animation: bridgeFlicker 3s infinite;
+  opacity: 1;
+}
+
+@keyframes bridgeFlicker {
+
+  0%,
+  100% {
+    opacity: 0.8;
+  }
+
+  5%,
+  15% {
+    opacity: 1.0;
+  }
+
+  10% {
+    opacity: 0.9;
+  }
 }
 
 .screen-occlusion {
@@ -42,7 +87,12 @@
   background: linear-gradient(to right, rgba(255, 255, 255, 0.12), transparent);
 }
 
-@media screen and (min-width: 40em) {
+@media screen and (min-width: 48em) {
+  .screen-viewport::before {
+    --direction: to bottom;
+    /* Switch to horizontal stripes on larger screens */
+  }
+
   .screen-rail {
     height: var(--bevel-width);
     width: 100%;
@@ -71,7 +121,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: auto;
+  grid-template-rows: auto auto 1fr 1fr;
   grid-template-areas:
     "transport"
     "worldview"
@@ -81,7 +131,7 @@
 
 }
 
-@media screen and (min-width: 40em) {
+@media screen and (min-width: 64em) {
   .screen-content {
     height: 100%;
     grid-template-columns: 2fr 1fr;

--- a/src/components/panels/physical/SleeveContainer.css
+++ b/src/components/panels/physical/SleeveContainer.css
@@ -34,7 +34,7 @@
   filter: drop-shadow(0 1px 0 rgba(0, 0, 0, 0.25));
 }
 
-@media screen and (min-width: 40em) {
+@media screen and (min-width: 48em) {
   .sleeve-container {
     width: var(--sleeve-width);
     min-width: var(--sleeve-width);

--- a/src/components/panels/screen/RobotList.css
+++ b/src/components/panels/screen/RobotList.css
@@ -1,5 +1,124 @@
+/* ========================================
+   Robot List — right-column robot picker
+   ======================================== */
+
+/* Status dot color tokens */
+:root {
+  --dot-idle: #7a8fa6;
+  --dot-moving: #f0a830;
+  --dot-selected: #4caf7d;
+  --dot-interacting: #4db6e8;
+  --dot-leaving: #c0403c;
+}
+
 .robot-list {
-  /* border: yellow 1px solid; */
   grid-area: robotlist;
   grid-row: span 2;
+
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  gap: 0;
+
+  border-left: var(--border-width, 1px) solid var(--color-border, rgba(255, 255, 255, 0.08));
+}
+
+/* ── Empty state ───────────────────────── */
+.robot-list__empty {
+  margin: auto;
+  padding: var(--spacing-md, 12px);
+  font-size: var(--font-size-sm, 12px);
+  color: var(--color-text-muted, rgba(255, 255, 255, 0.6));
+  text-align: center;
+}
+
+/* ── List items ────────────────────────── */
+.robot-list-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm, 8px);
+
+  /* Meets 44×44px touch-target minimum */
+  min-height: var(--touch-target-size, 44px);
+  padding: 4px var(--spacing-sm, 8px);
+
+  background: transparent;
+  border: none;
+  border-bottom: var(--border-width, 1px) solid var(--color-border, rgba(255, 255, 255, 0.08));
+  cursor: pointer;
+
+  text-align: left;
+  color: var(--color-text-primary, rgba(255, 255, 255, 0.87));
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm, 12px);
+
+  width: 100%;
+  box-sizing: border-box;
+  transition: background 0.1s;
+}
+
+.robot-list-item:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.robot-list-item--selected {
+  background: rgba(100, 108, 255, 0.12);
+  border-left: 2px solid var(--color-accent, #646cff);
+}
+
+/* ── Robot preview thumbnail ───────────── */
+.robot-list-item__preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.robot-list-item__preview-svg {
+  width: 36px;
+  height: 27px;
+  /* preserves 96:72 viewBox ratio */
+  pointer-events: none;
+  display: block;
+}
+
+/* ── Name ──────────────────────────────── */
+.robot-list-item__name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Status dot ────────────────────────── */
+.robot-list-item__dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--dot-color, var(--dot-idle));
+}
+
+.dot--idle {
+  --dot-color: var(--dot-idle);
+}
+
+.dot--moving {
+  --dot-color: var(--dot-moving);
+}
+
+.dot--selected {
+  --dot-color: var(--dot-selected);
+}
+
+.dot--interacting {
+  --dot-color: var(--dot-interacting);
+}
+
+.dot--leaving {
+  --dot-color: var(--dot-leaving);
 }

--- a/src/components/panels/screen/RobotList.tsx
+++ b/src/components/panels/screen/RobotList.tsx
@@ -1,9 +1,93 @@
-import './RobotList.css'
+// ========================================
+// IMPORTS
+// ========================================
+import { memo } from 'react';
 
+import type { Robot } from '../../../types/Robot';
+import { RobotState } from '../../../types/Robot';
+import { RobotBody } from '../../robot/RobotBody';
+
+import { useLocaleStore } from '../../../stores/localeStore';
+import { usePlanetStore } from '../../../stores/planetStore';
+import { useUIStore } from '../../../stores/uiStore';
+
+import './RobotList.css';
+
+// ========================================
+// TYPES
+// ========================================
+interface RobotListItemProps {
+  robot: Robot;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+}
+
+// ========================================
+// CONSTANTS
+// ========================================
+const STATE_DOT_CLASS: Record<string, string> = {
+  [RobotState.Idle]: 'dot--idle',
+  [RobotState.Moving]: 'dot--moving',
+  [RobotState.Selected]: 'dot--selected',
+  [RobotState.Interacting]: 'dot--interacting',
+  [RobotState.Leaving]: 'dot--leaving',
+};
+
+// ========================================
+// SUB-COMPONENT
+// ========================================
+const RobotListItem = memo(function RobotListItem({ robot, isSelected, onSelect }: RobotListItemProps) {
+  return (
+    <button
+      type="button"
+      className={`robot-list-item${isSelected ? ' robot-list-item--selected' : ''}`}
+      onClick={() => onSelect(robot.id)}
+      aria-pressed={isSelected}
+      aria-label={`Select ${robot.name ?? 'Robot'}`}
+    >
+      <span className="robot-list-item__preview" aria-hidden="true">
+        <svg
+          className="robot-list-item__preview-svg"
+          viewBox="0 0 96 72"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <RobotBody robot={robot} />
+        </svg>
+      </span>
+      <span className="robot-list-item__name">{robot.name ?? 'Robot'}</span>
+      <span className={`robot-list-item__dot ${STATE_DOT_CLASS[robot.state] ?? 'dot--idle'}`} aria-hidden="true" />
+    </button>
+  );
+});
+
+// ========================================
+// COMPONENT
+// ========================================
 function RobotList() {
+  const localeId = usePlanetStore((s) => s.planets[0]?.currentLocaleId ?? '');
+  const robots = useLocaleStore((s) => s.locales[localeId]?.robots ?? []);
+  const selectedRobotId = useUIStore((s) => s.selectedRobotId);
+
+  function handleSelect(id: string) {
+    useUIStore.getState().selectRobot(id);
+    useUIStore.getState().setActiveConsoleTab('robotEditor');
+  }
+
   return (
     <div className="robot-list">
-      Robot List
+      {robots.length === 0 ? (
+        <p className="robot-list__empty">No robots</p>
+      ) : (
+        robots.map((robot) => (
+          <RobotListItem
+            key={robot.id}
+            robot={robot}
+            isSelected={robot.id === selectedRobotId}
+            onSelect={handleSelect}
+          />
+        ))
+      )}
     </div>
   );
 }

--- a/src/components/panels/screen/TransportBar.css
+++ b/src/components/panels/screen/TransportBar.css
@@ -97,7 +97,7 @@
   flex-shrink: 0;
 }
 
-@media screen and (min-width: 40em) {
+@media screen and (min-width: 48em) {
   .transport-bar {
     position: relative;
   }

--- a/src/components/tablet/Tablet.css
+++ b/src/components/tablet/Tablet.css
@@ -1,22 +1,42 @@
 .tablet {
-  --mobile-tablet-size: calc(100% - 16px);
+  --tablet-max-width: calc(100% - 32px);
 
-  max-width: var(--mobile-tablet-size);
-  width: var(--mobile-tablet-size);
-  height: var(--mobile-tablet-size);
+  width: var(--tablet-max-width);
+  max-width: var(--tablet-max-width);
+  height: var(--tablet-max-width);
+  max-height: var(--tablet-max-width);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 }
 
-@media screen and (min-width: 40em) {
+@media screen and (min-width: 48em) {
   .tablet {
-    --tablet-max-width: 1440px;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width: 64em) {
+  .tablet {
+    --tablet-width: 960px;
     --tablet-aspect-ratio: 16 / 9;
 
-    width: var(--tablet-max-width);
-    height: calc(var(--tablet-max-width) / (var(--tablet-aspect-ratio)));
-    max-width: var(--tablet-max-width);
+    width: var(--tablet-width);
+    max-width: var(--tablet-width);
+    height: calc(var(--tablet-width) / (var(--tablet-aspect-ratio)));
     flex-direction: row;
+  }
+}
+
+@media screen and (min-width: 80em) {
+  .tablet {
+    --tablet-width: 1200px;
+
+  }
+}
+
+@media screen and (min-width: 92em) {
+  .tablet {
+    --tablet-width: 1440px;
   }
 }

--- a/src/components/ui/physical/PowerRockerSwitch.css
+++ b/src/components/ui/physical/PowerRockerSwitch.css
@@ -18,7 +18,7 @@
   transform: translateX(100%) rotate(90deg);
 }
 
-@media screen and (min-width: 40em) {
+@media screen and (min-width: 48em) {
   .rocker-panel {
     transform: none;
   }

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -489,9 +489,9 @@ function scheduleVoiceRelease(duration: NoteDuration, time: number): void {
     const transport = _transport ?? Tone.getTransport();
     transport.scheduleOnce(() => {
       activeVoices = Math.max(0, activeVoices - 1);
-      if (DEV_TUNING) {
-        console.log(`[AudioEngine] Voice released: ${activeVoices}/${MAX_POLYPHONY}`);
-      }
+      // if (DEV_TUNING) {
+      //   console.log(`[AudioEngine] Voice released: ${activeVoices}/${MAX_POLYPHONY}`);
+      // }
     }, `+${delayFromNow}`);
   } catch (err) {
     if (DEV_TUNING) swallow(err, 'AudioEngine.scheduleVoiceRelease');
@@ -1258,11 +1258,23 @@ export const AudioEngine = {
       return { synth, gainNode: layerGain, layer };
     });
 
+    // Per-layer last-scheduled time tracker. Tone Source nodes (Synth, NoiseSynth) require
+    // strictly increasing schedule times. We track the last time used per layer index so we
+    // can always advance by at least 1ms even when multiple flurries hit the same composite
+    // in the same AudioContext quantum (where Tone.now() returns the same value for all calls).
+    const layerLastTime: number[] = layerNodes.map(() => -Infinity);
+
     const triggerAttackRelease = (note: string, dur: NoteDuration | string, time?: number, velocity?: number) => {
-      const t = (typeof time === 'number' && isFinite(time)) ? time : Tone.now();
+      const requested = (typeof time === 'number' && isFinite(time)) ? time : Tone.now();
       const durStr = String(dur);
-      layerNodes.forEach(({ synth, layer }) => {
+      layerNodes.forEach(({ synth, layer }, i) => {
         try {
+          // Guarantee strictly increasing time per layer: Tone Source nodes (Synth, NoiseSynth)
+          // require each scheduled time to be > the previous one on that same source instance.
+          // Multiple flurries in the same AudioContext quantum share the same Tone.now() value,
+          // so we advance by at least 1ms beyond both the requested time and the last used time.
+          const t = Math.max(requested, Tone.now() + 0.001, layerLastTime[i] + 0.001);
+          layerLastTime[i] = t;
           const isNoise = layer.type === 'noise';
           if (synth && typeof (synth as unknown as { triggerAttackRelease?: unknown }).triggerAttackRelease === 'function') {
             if (isNoise) {

--- a/src/index.css
+++ b/src/index.css
@@ -66,18 +66,6 @@ body {
   height: 100vh;
 }
 
-@media (min-width: 768px) {
-  :root {
-    --sleeve-width: var(--sleeve-width-tablet);
-  }
-}
-
-@media (min-width: 1200px) {
-  :root {
-    --sleeve-width: var(--sleeve-width-desktop);
-  }
-}
-
 h1 {
   font-size: 3.2em;
   line-height: 1.1;

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -6,6 +6,7 @@ import { create } from 'zustand';
 
 export type ActiveView = 'ocean' | 'robot' | 'composition' | 'fx' | 'settings';
 export type Theme = 'dark' | 'light';
+export type ConsoleTab = 'robotEditor';
 
 export interface UIStore {
   activeView: ActiveView;
@@ -15,6 +16,7 @@ export interface UIStore {
   isFullscreen: boolean;
   activeLocaleLocalTime: number | null;
   selectedRobotId: string | null;
+  activeConsoleTab: ConsoleTab | null;
   setActiveLocaleLocalTime: (t: number | null) => void;
   setActiveView: (v: ActiveView) => void;
   setTheme: (t: Theme) => void;
@@ -23,6 +25,7 @@ export interface UIStore {
   setPowerOn: () => void;
   setPowerOff: () => void;
   selectRobot: (id: string | null) => void;
+  setActiveConsoleTab: (tab: ConsoleTab | null) => void;
 }
 
 // ========================================
@@ -37,6 +40,7 @@ export const useUIStore = create<UIStore>((set) => ({
   isPoweredOn: false,
   activeLocaleLocalTime: null,
   selectedRobotId: null,
+  activeConsoleTab: null,
 
   setActiveView: (v) => set({ activeView: v }),
   setTheme: (t) => set({ theme: t }),
@@ -46,6 +50,7 @@ export const useUIStore = create<UIStore>((set) => ({
   setPowerOff: () => set({ isPoweredOn: false }),
   setActiveLocaleLocalTime: (t) => set({ activeLocaleLocalTime: t }),
   selectRobot: (id) => set({ selectedRobotId: id }),
+  setActiveConsoleTab: (tab) => set({ activeConsoleTab: tab }),
 }));
 
 // ========================================


### PR DESCRIPTION
- Replace RobotList stub with scrollable robot picker reading from localeStore; selection sets selectedRobotId and switches Console to robotEditor tab via new activeConsoleTab in uiStore
- Add ConsoleTab type, activeConsoleTab state, and setActiveConsoleTab action to uiStore
- Fix composite voice layer trigger: track per-layer last-scheduled time to guarantee strictly increasing AudioContext times; prevents Start time must be strictly greater than previous start time assert on NoiseSynth/Synth when interaction flurries fire in the same AudioContext quantum
- Overhaul responsive breakpoints across Tablet, ScreenViewport, SleeveContainer, TransportBar, and PowerRockerSwitch (40em → 48em/ 64em/80em/92em); add fluid tablet sizing via --tablet-width steps
- Add holographic CRT stripe effect to ScreenViewport via ::before pseudo-element with bridgeFlicker animation
- Remove duplicate --sleeve-width media query overrides from index.css

Closes #246
