### PR TITLE
Add seedUtils, getSeededVal, and noiseMaps utilities for deterministic

### DIFF
--- a/src/stores/planetStore.ts
+++ b/src/stores/planetStore.ts
@@ -1,8 +1,16 @@
 import { create } from 'zustand';
 
 import type { Planet, PlanetSize } from '../types/planet';
+import { PLANET_DURATION_MS } from '../constants/time';
+import { derivePlanetSeed, planetInitialHour } from '../utils/seedUtils';
 
 export const DEFAULT_LOCALE_ID = 'pelagos-default';
+
+function makeDayStartTimestamp(planetName: string, size: PlanetSize): number {
+  const seed = derivePlanetSeed(planetName);
+  const initialHour = planetInitialHour(seed);
+  return Date.now() - (initialHour / 24) * PLANET_DURATION_MS[size];
+}
 
 export const DEFAULT_PELAGOS: Planet = {
   id: 'pelagos',
@@ -10,13 +18,13 @@ export const DEFAULT_PELAGOS: Planet = {
   size: 'medium',
   locales: [DEFAULT_LOCALE_ID],
   currentLocaleId: DEFAULT_LOCALE_ID,
-  dayStartTimestamp: Date.now(),
+  dayStartTimestamp: makeDayStartTimestamp('Pelagos', 'medium'),
   currentHour: 0,
 };
 
 export interface PlanetStore {
   planets: Planet[];
-  addPlanet: (planet: Planet) => void;
+  addPlanet: (planet: Planet) => boolean;
   removePlanet: (planetId: string) => void;
   setPlanetSize: (planetId: string, size: PlanetSize) => void;
   setDayStartTimestamp: (planetId: string, ts: number) => void;
@@ -27,10 +35,27 @@ export interface PlanetStore {
 export const usePlanetStore = create<PlanetStore>((set) => ({
   planets: [DEFAULT_PELAGOS],
 
-  addPlanet: (planet) =>
-    set((state) => ({
-      planets: [...state.planets, planet],
-    })),
+  addPlanet: (planet) => {
+    let added = false;
+    set((state) => {
+      const nameTaken = state.planets.some(
+        (p) => p.name.toLowerCase() === planet.name.toLowerCase()
+      );
+      if (nameTaken) {
+        console.warn(
+          `[planetStore] addPlanet: planet name "${planet.name}" is already taken. Planet not added.`
+        );
+        return state;
+      }
+      const seed = derivePlanetSeed(planet.name);
+      const initialHour = planetInitialHour(seed);
+      const dayStartTimestamp =
+        Date.now() - (initialHour / 24) * PLANET_DURATION_MS[planet.size];
+      added = true;
+      return { planets: [...state.planets, { ...planet, dayStartTimestamp }] };
+    });
+    return added;
+  },
 
   removePlanet: (planetId) =>
     set((state) => ({

--- a/src/utils/getSeededVal.ts
+++ b/src/utils/getSeededVal.ts
@@ -1,0 +1,57 @@
+// ========================================
+// IMPORTS
+// ========================================
+import alea from 'alea';
+import type { NoiseFunction2D } from 'simplex-noise';
+
+// ========================================
+// FUNCTIONS
+// ========================================
+
+/**
+ * Convert a stable dataId string into a deterministic float in [0, 1].
+ * This is the x-axis value passed to a noise map for a given data key.
+ *
+ * **Hot-path callers (e.g. AudioEngine scheduling) must call this ONCE at
+ * module scope and cache the result.** `alea(dataId)()` involves string
+ * hashing — calling it hundreds of times per second is measurably slower
+ * than Math.random() and can delay the Tone.js scheduling callback.
+ *
+ * Pattern for audio hot paths:
+ *   // module scope — computed once at import time:
+ *   const MY_KEY_X = precomputeDataX('my.data.key');
+ *
+ *   // inside the hot path:
+ *   const value = noiseMap(MY_KEY_X, offset);
+ */
+export function precomputeDataX(dataId: string): number {
+  return alea(dataId)();
+}
+
+/**
+ * Sample a locale noise map at a deterministic (dataId, offset) position
+ * and map the [-1, 1] result to [min, max].
+ *
+ * **Do not call this on the audio scheduling hot path.** Use
+ * `precomputeDataX` to cache the x value at module scope and call
+ * `noiseMap(x, offset)` directly inside the scheduling callback.
+ *
+ * @param noiseMap  The locale's 2D noise function (from noiseMaps registry)
+ * @param dataId    A stable, unique string key — use the Zustand state key path
+ *                  (e.g. 'robots.audioAttributes.waveform') so values are
+ *                  consistent across app instances
+ * @param offset    Array index for per-element variation (e.g. robot spawn order); default 0
+ * @param min       Output range minimum; default 0
+ * @param max       Output range maximum; default 1
+ */
+export function getSeededVal(
+  noiseMap: NoiseFunction2D,
+  dataId: string,
+  offset = 0,
+  min = 0,
+  max = 1,
+): number {
+  const x = precomputeDataX(dataId);
+  const raw = noiseMap(x, offset); // simplex noise in [-1, 1]
+  return min + ((raw + 1) / 2) * (max - min);
+}

--- a/src/utils/noiseMaps.ts
+++ b/src/utils/noiseMaps.ts
@@ -1,0 +1,63 @@
+// ========================================
+// IMPORTS
+// ========================================
+import alea from 'alea';
+import { createNoise2D, type NoiseFunction2D } from 'simplex-noise';
+
+import { derivePlanetSeed } from './seedUtils';
+
+// ========================================
+// REGISTRY (module-level, non-serialisable — must NOT be stored in Zustand)
+// ========================================
+const planetMaps = new Map<string, NoiseFunction2D>();
+const localeMaps = new Map<string, NoiseFunction2D>();
+
+// ========================================
+// FUNCTIONS
+// ========================================
+
+/** Create (or return cached) the 2D noise map for a planet, keyed by planet ID. */
+export function getPlanetNoiseMap(planetId: string, planetName: string): NoiseFunction2D {
+  if (!planetMaps.has(planetId)) {
+    const seed = derivePlanetSeed(planetName);
+    planetMaps.set(planetId, createNoise2D(alea(seed)));
+  }
+  return planetMaps.get(planetId)!;
+}
+
+/**
+ * Create (or return cached) the 2D noise map for a locale.
+ *
+ * The locale seed is derived by:
+ *   1. Sampling the planet's noise map at the locale's coordinates (returns [-1, 1])
+ *   2. Mapping that float to an integer in [0, 129,599] via localeCoordSeed
+ *   3. Seeding createNoise2D with alea(integer)
+ *
+ * Two locales with identical coordinates on different planets will have
+ * different noise maps because step 1 samples a planet-specific noise function.
+ */
+export function getLocaleNoiseMap(
+  localeId: string,
+  planetId: string,
+  planetName: string,
+  x: number,
+  y: number,
+): NoiseFunction2D {
+  if (!localeMaps.has(localeId)) {
+    const planetMap = getPlanetNoiseMap(planetId, planetName);
+    const rawSeed = planetMap(x, y); // -1 to 1
+    const intSeed = Math.round(((rawSeed + 1) / 2) * (360 * 360 - 1)); // 0–129,599
+    localeMaps.set(localeId, createNoise2D(alea(intSeed)));
+  }
+  return localeMaps.get(localeId)!;
+}
+
+/** Remove a planet noise map from the registry (call when a planet is removed). */
+export function evictPlanetNoiseMap(planetId: string): void {
+  planetMaps.delete(planetId);
+}
+
+/** Remove a locale noise map from the registry (call when a locale is removed). */
+export function evictLocaleNoiseMap(localeId: string): void {
+  localeMaps.delete(localeId);
+}

--- a/src/utils/seedUtils.ts
+++ b/src/utils/seedUtils.ts
@@ -1,0 +1,50 @@
+// ========================================
+// IMPORTS
+// ========================================
+// (none — pure string/math utilities)
+
+// ========================================
+// FUNCTIONS
+// ========================================
+
+/**
+ * Derive a stable planet seed string from the planet's display name.
+ * Lowercases, strips any character that is not a-z or 0-9.
+ * E.g. "Pelagos 7!" → "pelagos7"
+ */
+export function derivePlanetSeed(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/**
+ * Compute the planet's deterministic initial in-world hour (integer 0–23)
+ * from the planet seed.
+ *
+ * Algorithm: convert each letter in the seed to its 0-based index (a=0 … z=25),
+ * take the floor of the average. If the result is outside [0, 23] (possible if
+ * all characters are digits), fall back to 0.
+ */
+export function planetInitialHour(seed: string): number {
+  const letters = seed.replace(/[^a-z]/g, '');
+  if (!letters.length) return 0;
+  const avg =
+    letters.split('').reduce((sum, ch) => sum + (ch.charCodeAt(0) - 97), 0) /
+    letters.length;
+  const hour = Math.floor(avg);
+  return hour >= 0 && hour <= 23 ? hour : 0;
+}
+
+/**
+ * Convert a locale's (x, y) integer coordinates into a unique seed integer.
+ *
+ * Coordinates are assumed to be integers in the range -179…179.
+ * The total number of distinct (x, y) pairs is 359 × 359 = 128,881.
+ * Using 360 × 360 = 129,600 as the upper-bound constant is safe and
+ * slightly conservative (128,881 < 129,600).
+ *
+ * The resulting integer is then passed to `alea()` to seed the locale
+ * noise map via `createNoise2D(alea(localeCoordSeed(x, y)))`.
+ */
+export function localeCoordSeed(x: number, y: number): number {
+  return (x + 180) * 360 + (y + 180); // 0 … 129,599
+}


### PR DESCRIPTION
seed-based value generation. Update planetStore.addPlanet to return boolean, enforce unique planet names, and derive dayStartTimestamp from planetInitialHour.
Closes #262
