### PR TITLE
Prime noise map cache on add and evict on remove for planets and loca…

### DIFF
--- a/src/stores/localeStore.ts
+++ b/src/stores/localeStore.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand';
 
 import type { Locale, LocaleState } from '../types/locale';
 import { DEFAULT_LOCALE_ID } from './planetStore';
+import { usePlanetStore } from './planetStore';
+import { getLocaleNoiseMap, evictLocaleNoiseMap } from '../utils/noiseMaps';
 
 const DEFAULT_LOCALE: Locale = {
   id: DEFAULT_LOCALE_ID,
@@ -14,12 +16,18 @@ const DEFAULT_LOCALE: Locale = {
   currentMeasure: 0,
 };
 
+getLocaleNoiseMap(DEFAULT_LOCALE_ID, 'pelagos', 'Pelagos', 0, 0);
+
 export const useLocaleStore = create<LocaleState>((set, get) => ({
   locales: { [DEFAULT_LOCALE_ID]: DEFAULT_LOCALE },
 
   addLocale: (planetId, locale) => {
     const toAdd: Locale = { ...locale, planetId };
     set((state) => ({ locales: { ...state.locales, [toAdd.id]: toAdd } }));
+    const planet = usePlanetStore.getState().planets.find((p) => p.id === planetId);
+    if (planet) {
+      getLocaleNoiseMap(toAdd.id, planetId, planet.name, toAdd.coordinates.x, toAdd.coordinates.y);
+    }
   },
 
   setLocaleData: (localeId, partial) => {
@@ -41,6 +49,7 @@ export const useLocaleStore = create<LocaleState>((set, get) => ({
       delete next[localeId];
       return { locales: next };
     });
+    evictLocaleNoiseMap(localeId);
   },
 
   getLocaleById: (localeId) => get().locales[localeId],

--- a/src/stores/planetStore.ts
+++ b/src/stores/planetStore.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 import type { Planet, PlanetSize } from '../types/planet';
 import { PLANET_DURATION_MS } from '../constants/time';
 import { derivePlanetSeed, planetInitialHour } from '../utils/seedUtils';
+import { getPlanetNoiseMap, evictPlanetNoiseMap, evictLocaleNoiseMap } from '../utils/noiseMaps';
 
 export const DEFAULT_LOCALE_ID = 'pelagos-default';
 
@@ -21,6 +22,8 @@ export const DEFAULT_PELAGOS: Planet = {
   dayStartTimestamp: makeDayStartTimestamp('Pelagos', 'medium'),
   currentHour: 0,
 };
+
+getPlanetNoiseMap('pelagos', 'Pelagos');
 
 export interface PlanetStore {
   planets: Planet[];
@@ -52,15 +55,21 @@ export const usePlanetStore = create<PlanetStore>((set) => ({
       const dayStartTimestamp =
         Date.now() - (initialHour / 24) * PLANET_DURATION_MS[planet.size];
       added = true;
+      getPlanetNoiseMap(planet.id, planet.name);
       return { planets: [...state.planets, { ...planet, dayStartTimestamp }] };
     });
     return added;
   },
 
   removePlanet: (planetId) =>
-    set((state) => ({
-      planets: state.planets.filter((p) => p.id !== planetId),
-    })),
+    set((state) => {
+      const planet = state.planets.find((p) => p.id === planetId);
+      if (planet) {
+        planet.locales.forEach((localeId) => evictLocaleNoiseMap(localeId));
+        evictPlanetNoiseMap(planetId);
+      }
+      return { planets: state.planets.filter((p) => p.id !== planetId) };
+    }),
 
   setPlanetSize: (planetId, size) =>
     set((state) => ({


### PR DESCRIPTION
…les.

Prime default maps at module scope to avoid null-check races on first render. Closes #263