### PR TITLE
feat(systems): seed RNG with locale noise maps; fix idle destinations

### DIFF
--- a/src/systems/factorySystem.ts
+++ b/src/systems/factorySystem.ts
@@ -5,11 +5,13 @@ import type { Actor } from '../types/Actor';
 import type { Robot } from '../types/Robot';
 import { RobotState } from '../types/Robot';
 import useLocaleStore from '../stores/localeStore';
+import { usePlanetStore } from '../stores/planetStore';
 import type { LocaleSettings } from '../types/locale';
 import { AudioEngine } from '../engine/AudioEngine';
 import { scheduleRepeat, cancelSchedule } from '../engine/beatClock';
 import { generateMelodyForRobot } from '../engine/melodyGenerator';
 import { generateAudioAttributes } from './spawnSystem';
+import { getLocaleNoiseMap } from '../utils/noiseMaps';
 import { DEV_TUNING } from '../constants';
 
 // ========================================
@@ -138,7 +140,16 @@ export function stopFactoryProduction(factoryId: string): void {
  * Create a robot spawned from a factory.
  * Robot starts at factory position in idle state.
  */
-export function createRobotFromFactory(factory: Actor): Robot {
+export function createRobotFromFactory(factory: Actor, localeId?: string): Robot {
+  // Resolve locale noise map for deterministic attribute generation when available
+  const locale = localeId ? useLocaleStore.getState().getLocaleById(localeId) : undefined;
+  const planet = locale ? usePlanetStore.getState().planets.find((p) => p.id === locale.planetId) : undefined;
+  const noiseMap = locale && planet
+    ? getLocaleNoiseMap(localeId!, locale.planetId, planet.name, locale.coordinates.x, locale.coordinates.y)
+    : null;
+  // Use factory ID as a stable offset seed so each factory produces distinct robots
+  const offset = noiseMap ? (factory.id.charCodeAt(0) ?? 0) : 0;
+
   return {
     id: crypto.randomUUID(),
     state: RobotState.Idle,
@@ -146,7 +157,11 @@ export function createRobotFromFactory(factory: Actor): Robot {
     destination: null,
     direction: 'right',
     melody: generateMelodyForRobot(),
-    audioAttributes: generateAudioAttributes(),
+    audioAttributes: noiseMap ? generateAudioAttributes(noiseMap, offset) : generateAudioAttributes(
+      // Inline trivial fallback noise map (uniform midpoint) when locale is unavailable
+      (() => { const fn = (_x: number, _y: number) => 0 as number; return fn; })() as Parameters<typeof generateAudioAttributes>[0],
+      offset,
+    ),
     // sensible defaults for required audio/visual ranges
     octaveRange: [3, 5],
     masterVolume: 0.9,

--- a/src/systems/idleSystem.test.ts
+++ b/src/systems/idleSystem.test.ts
@@ -2,8 +2,12 @@
 // IMPORTS
 // ========================================
 import { describe, it, expect } from 'vitest';
+import type { NoiseFunction2D } from 'simplex-noise';
 
 import { pickDestination } from './idleSystem';
+
+/** General-purpose mock: returns a pseudo-random value in [-1, 1]. */
+const mockNoiseMap: NoiseFunction2D = () => Math.random() * 2 - 1;
 
 // ========================================
 // TESTS
@@ -12,7 +16,7 @@ import { pickDestination } from './idleSystem';
 describe('idleSystem', () => {
   describe('pickDestination', () => {
     it('generates destination within world bounds', () => {
-      const destination = pickDestination();
+      const destination = pickDestination(mockNoiseMap, 0, 0);
       expect(destination.x).toBeGreaterThanOrEqual(0);
       expect(destination.x).toBeLessThanOrEqual(1920);
       expect(destination.y).toBeGreaterThanOrEqual(0);
@@ -21,7 +25,7 @@ describe('idleSystem', () => {
 
     it('generates destination with margin from edges', () => {
       const WORLD_MARGIN = 100;
-      const destination = pickDestination();
+      const destination = pickDestination(mockNoiseMap, 0, 0);
 
       // Should be at least WORLD_MARGIN from edges
       expect(destination.x).toBeGreaterThanOrEqual(WORLD_MARGIN);
@@ -31,7 +35,7 @@ describe('idleSystem', () => {
     });
 
     it('generates varied destinations (not all the same)', () => {
-      const destinations = Array.from({ length: 20 }, () => pickDestination());
+      const destinations = Array.from({ length: 20 }, (_, i) => pickDestination(mockNoiseMap, 0, i));
       const uniqueX = new Set(destinations.map((d) => Math.round(d.x)));
       const uniqueY = new Set(destinations.map((d) => Math.round(d.y)));
 
@@ -41,7 +45,7 @@ describe('idleSystem', () => {
     });
 
     it('generates destinations in center area (not just edges)', () => {
-      const destinations = Array.from({ length: 100 }, () => pickDestination());
+      const destinations = Array.from({ length: 100 }, (_, i) => pickDestination(mockNoiseMap, 0, i));
 
       // At least some should be in center region (away from all edges)
       const centerRegion = destinations.filter(
@@ -56,7 +60,7 @@ describe('idleSystem', () => {
     });
 
     it('uses full available space (not clustered)', () => {
-      const destinations = Array.from({ length: 100 }, () => pickDestination());
+      const destinations = Array.from({ length: 100 }, (_, i) => pickDestination(mockNoiseMap, 0, i));
 
       // Check distribution across quadrants
       const leftHalf = destinations.filter((d) => d.x < 960).length;

--- a/src/systems/idleSystem.ts
+++ b/src/systems/idleSystem.ts
@@ -3,10 +3,14 @@
 // ========================================
 import gsap from 'gsap';
 
-import type { Vec2 } from '../types/Vec2';
+import type { NoiseFunction2D } from 'simplex-noise';
 import { RobotState } from '../types/Robot';
 import useLocaleStore from '../stores/localeStore';
+import { usePlanetStore } from '../stores/planetStore';
 import { createSwimTimeline } from '../animation/swimAnimation';
+import { getLocaleNoiseMap } from '../utils/noiseMaps';
+import { getSeededVal } from '../utils/getSeededVal';
+import type { Vec2 } from '../types/Vec2';
 
 // ========================================
 // CONSTANTS
@@ -22,15 +26,41 @@ const IDLE_DELAY = 1.0; // Seconds before picking next destination
 /** Track pending idle delays by robot ID to allow cleanup */
 const pendingIdleDelays = new Map<string, gsap.core.Tween>();
 
+/** Per-robot move counter — incremented each time a robot picks a new idle destination.
+ *  Stores the robot's spawn index (for its unique noise channel) and current move count. */
+const idleMoveCounters = new Map<string, { spawnIndex: number; count: number }>();
+
+function getAndIncrementMoveCount(robotId: string): { spawnIndex: number; count: number } {
+  const entry = idleMoveCounters.get(robotId) ?? { spawnIndex: 0, count: 0 };
+  idleMoveCounters.set(robotId, { ...entry, count: entry.count + 1 });
+  return entry;
+}
+
+/**
+ * Seed the idle move counter for a robot at spawn time.
+ * Pass the robot's spawn index so each robot gets its own noise channel.
+ */
+export function initRobotIdleCounter(robotId: string, spawnIndex: number): void {
+  idleMoveCounters.set(robotId, { spawnIndex, count: 0 });
+}
+
 // ========================================
 // EXPORTS
 // ========================================
 
 /**
- * Pick a random destination within world bounds
- * Keeps destinations away from edges by WORLD_MARGIN
+ * Pick a destination within world bounds using seeded noise.
+ * Each robot has a unique noise channel determined by its spawnIndex,
+ * so robots never follow correlated paths regardless of their move count.
+ * Falls back to Math.random if noiseMap is unavailable.
  */
-export function pickDestination(): Vec2 {
+export function pickDestination(noiseMap: NoiseFunction2D | null, spawnIndex: number, moveCount: number): Vec2 {
+  if (noiseMap) {
+    return {
+      x: getSeededVal(noiseMap, `idle.target.x.${spawnIndex}`, moveCount, WORLD_MARGIN, WORLD_WIDTH - WORLD_MARGIN),
+      y: getSeededVal(noiseMap, `idle.target.y.${spawnIndex}`, moveCount, WORLD_MARGIN, WORLD_HEIGHT - WORLD_MARGIN),
+    };
+  }
   return {
     x: WORLD_MARGIN + Math.random() * (WORLD_WIDTH - 2 * WORLD_MARGIN),
     y: WORLD_MARGIN + Math.random() * (WORLD_HEIGHT - 2 * WORLD_MARGIN),
@@ -44,7 +74,8 @@ export function pickDestination(): Vec2 {
 export function handleRobotIdle(localeId: string, robotId: string): void {
   // console.log(`[IdleSystem] handleRobotIdle called for robot ${robotId}`);
 
-  const robot = useLocaleStore.getState().getRobotById(localeId, robotId);
+  const store = useLocaleStore.getState();
+  const robot = store.getRobotById(localeId, robotId);
 
   // Guard: robot must exist and be in idle state
   if (!robot || robot.state !== RobotState.Idle) {
@@ -52,7 +83,19 @@ export function handleRobotIdle(localeId: string, robotId: string): void {
     return;
   }
 
-  const destination = pickDestination();
+  // Resolve locale noise map for deterministic destination
+  const locale = store.getLocaleById(localeId);
+  const planet = locale ? usePlanetStore.getState().planets.find((p) => p.id === locale.planetId) : undefined;
+  const noiseMap = locale && planet
+    ? getLocaleNoiseMap(localeId, locale.planetId, planet.name, locale.coordinates.x, locale.coordinates.y)
+    : null;
+
+  // Each robot has a unique spawnIndex (its noise channel) and an ever-incrementing
+  // move count. Together they guarantee a distinct, non-overlapping noise sequence
+  // for every robot across all time.
+  const { spawnIndex, count } = getAndIncrementMoveCount(robotId);
+
+  const destination = pickDestination(noiseMap, spawnIndex, count);
 
   // Calculate direction based on destination x-coordinate relative to current position
   const direction = destination.x > robot.position.x ? 'right' : 'left';
@@ -113,6 +156,7 @@ export function cancelPendingIdleDelay(robotId: string): void {
     delayTween.kill();
     pendingIdleDelays.delete(robotId);
   }
+  idleMoveCounters.delete(robotId);
 }
 
 // (no default wrappers) callers must provide explicit localeId

--- a/src/systems/interactionSystem.ts
+++ b/src/systems/interactionSystem.ts
@@ -7,11 +7,14 @@ import { getAvailableNotes } from '../engine/harmonySystem';
 import { AudioEngine } from '../engine/AudioEngine';
 import { getCurrentMeasure } from '../engine/beatClock';
 import useLocaleStore from '../stores/localeStore';
+import { usePlanetStore } from '../stores/planetStore';
 import { RobotState } from '../types/Robot';
 import { DEV_TUNING } from '../constants';
 import { handleRobotIdle } from './idleSystem';
 import { killTimeline } from '../animation/timelineMap';
 import { getRef } from '../utils/refs';
+import { getLocaleNoiseMap } from '../utils/noiseMaps';
+import { getSeededVal } from '../utils/getSeededVal';
 
 // ========================================
 // CONSTANTS
@@ -42,14 +45,26 @@ function playInteractionFlurry(localeId: string, robotAId: string, robotBId: str
     return;
   }
 
+  // Resolve locale noise map for deterministic event selection
+  const locale = store.getLocaleById(localeId);
+  const planet = locale ? usePlanetStore.getState().planets.find((p) => p.id === locale.planetId) : undefined;
+  const noiseMap = locale && planet
+    ? getLocaleNoiseMap(localeId, locale.planetId, planet.name, locale.coordinates.x, locale.coordinates.y)
+    : null;
+
+  // Stable robot indices for offset calculation
+  const robotAIndex = locale?.robots.findIndex((r) => r.id === robotAId) ?? 0;
+  const robotBIndex = locale?.robots.findIndex((r) => r.id === robotBId) ?? 1;
+
   const noteSpacing = 0.125; // 16th note spacing in seconds
-  // Capture the current AudioContext time once so all offsets are relative
-  // to the same reference point (avoids drift from repeated Tone.now() calls).
   const baseTime = AudioEngine.now();
 
   // Schedule flurry from Robot A (starting at baseTime)
   for (let i = 0; i < FLURRY_NOTE_COUNT && i < robotA.melody.length; i++) {
-    const randomEventA = robotA.melody[Math.floor(Math.random() * robotA.melody.length)];
+    const eventIndex = noiseMap
+      ? Math.floor(getSeededVal(noiseMap, 'interaction.eventA', robotAIndex + i, 0, robotA.melody.length))
+      : Math.floor(Math.random() * robotA.melody.length);
+    const randomEventA = robotA.melody[eventIndex];
     const noteName = notes[randomEventA.noteIndex];
 
     if (noteName) {
@@ -65,7 +80,10 @@ function playInteractionFlurry(localeId: string, robotAId: string, robotBId: str
 
   // Schedule flurry from Robot B (slightly staggered overlap)
   for (let i = 0; i < FLURRY_NOTE_COUNT && i < robotB.melody.length; i++) {
-    const randomEventB = robotB.melody[Math.floor(Math.random() * robotB.melody.length)];
+    const eventIndex = noiseMap
+      ? Math.floor(getSeededVal(noiseMap, 'interaction.eventB', robotBIndex + i, 0, robotB.melody.length))
+      : Math.floor(Math.random() * robotB.melody.length);
+    const randomEventB = robotB.melody[eventIndex];
     const noteName = notes[randomEventB.noteIndex];
 
     if (noteName) {

--- a/src/systems/spawnSystem.test.ts
+++ b/src/systems/spawnSystem.test.ts
@@ -2,6 +2,7 @@
 // IMPORTS
 // ========================================
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { NoiseFunction2D } from 'simplex-noise';
 import type { Robot } from '../types/Robot';
 
 import { generateSpawnPosition, generateAudioAttributes, spawnRobot } from './spawnSystem';
@@ -9,6 +10,12 @@ import { useLocaleStore, DEFAULT_LOCALE } from '../stores/localeStore';
 import { DEFAULT_LOCALE_ID } from '../stores/planetStore';
 import { AudioEngine } from '../engine/AudioEngine';
 import { RobotState } from '../types/Robot';
+
+/** General-purpose mock: returns a pseudo-random value in [-1, 1]. */
+const mockNoiseMap: NoiseFunction2D = () => Math.random() * 2 - 1;
+
+/** Deterministic mock: always returns -1, mapping every getSeededVal call to its min value. */
+const deterministicNoiseMap: NoiseFunction2D = () => -1;
 
 vi.mock('../engine/beatClock', () => ({
   scheduleRepeat: vi.fn(() => 'beat-spawn-1'),
@@ -22,7 +29,7 @@ vi.mock('../engine/beatClock', () => ({
 describe('spawnSystem', () => {
   describe('generateSpawnPosition', () => {
     it('generates position just outside world bounds (off-screen)', () => {
-      const position = generateSpawnPosition();
+      const position = generateSpawnPosition(mockNoiseMap, 0);
       // Must be outside the viewBox on at least one axis
       const outsideX = position.x < 0 || position.x > 1920;
       const outsideY = position.y < 0 || position.y > 1080;
@@ -30,7 +37,7 @@ describe('spawnSystem', () => {
     });
 
     it('generates positions on all four edges (off-screen)', () => {
-      const positions = Array.from({ length: 100 }, () => generateSpawnPosition());
+      const positions = Array.from({ length: 100 }, (_, i) => generateSpawnPosition(mockNoiseMap, i));
 
       const leftEdge = positions.filter((p) => p.x < 0).length;
       const rightEdge = positions.filter((p) => p.x > 1920).length;
@@ -45,7 +52,7 @@ describe('spawnSystem', () => {
     });
 
     it('generates varied positions (not all the same)', () => {
-      const positions = Array.from({ length: 20 }, () => generateSpawnPosition());
+      const positions = Array.from({ length: 20 }, (_, i) => generateSpawnPosition(mockNoiseMap, i));
       const uniqueX = new Set(positions.map((p) => Math.round(p.x)));
       const uniqueY = new Set(positions.map((p) => Math.round(p.y)));
 
@@ -56,7 +63,7 @@ describe('spawnSystem', () => {
 
   describe('generateAudioAttributes', () => {
     it('generates valid synth type', () => {
-      const attrs = generateAudioAttributes();
+      const attrs = generateAudioAttributes(mockNoiseMap, 0);
       expect([
         'AMSynth',
         'FMSynth',
@@ -66,7 +73,7 @@ describe('spawnSystem', () => {
     });
 
     it('generates ADSR values in valid ranges', () => {
-      const attrs = generateAudioAttributes();
+      const attrs = generateAudioAttributes(mockNoiseMap, 0);
       expect(attrs.adsr.attack).toBeGreaterThanOrEqual(0.01);
       expect(attrs.adsr.attack).toBeLessThanOrEqual(0.5);
       expect(attrs.adsr.decay).toBeGreaterThanOrEqual(0.1);
@@ -78,7 +85,7 @@ describe('spawnSystem', () => {
     });
 
     it('generates pitch range from predefined options', () => {
-      const attrs = generateAudioAttributes();
+      const attrs = generateAudioAttributes(mockNoiseMap, 0);
       const validRanges = [
         { min: 80, max: 150 },
         { min: 250, max: 450 },
@@ -94,13 +101,13 @@ describe('spawnSystem', () => {
     });
 
     it('generates filter frequency in valid range', () => {
-      const attrs = generateAudioAttributes();
+      const attrs = generateAudioAttributes(mockNoiseMap, 0);
       expect(attrs.filterFreq).toBeGreaterThanOrEqual(400);
       expect(attrs.filterFreq).toBeLessThanOrEqual(2500);
     });
 
     it('generates varied attributes (not all the same)', () => {
-      const attributes = Array.from({ length: 20 }, () => generateAudioAttributes());
+      const attributes = Array.from({ length: 20 }, (_, i) => generateAudioAttributes(mockNoiseMap, i));
       const uniqueSynthTypes = new Set(attributes.map((a) => a.synthType));
       const uniqueAttacks = new Set(attributes.map((a) => a.adsr.attack.toFixed(2)));
 
@@ -109,7 +116,7 @@ describe('spawnSystem', () => {
     });
 
     it('creates layeredWave with 1..3 layers and shapeParams in range', () => {
-      const attrs = generateAudioAttributes();
+      const attrs = generateAudioAttributes(mockNoiseMap, 0);
       const vm = attrs.visualAudioMap;
       expect(vm).toBeDefined();
       expect(vm?.layeredWave).toBeDefined();
@@ -132,24 +139,20 @@ describe('spawnSystem', () => {
     });
 
     it('averagedADSR equals single layer ADSR when only one layer (deterministic)', () => {
-      // Make Math.random deterministic to force single-layer and known values
-      const rnd = vi.spyOn(Math, 'random').mockImplementation(() => 0);
-      try {
-        const attrs = generateAudioAttributes();
-        const vm = attrs.visualAudioMap!;
-        const layers = vm.layeredWave?.layers ?? [];
-        // With Math.random=0 we should get exactly 1 layer
-        expect(layers.length).toBe(1);
-        const layerAdsr = layers[0].adsr!;
-        const avg = vm.averagedADSR!;
-        // The averaged should equal the single layer's values
-        expect(avg.attack).toBeCloseTo(layerAdsr.attack as number, 6);
-        expect(avg.decay).toBeCloseTo(layerAdsr.decay as number, 6);
-        expect(avg.sustain).toBeCloseTo(layerAdsr.sustain as number, 6);
-        expect(avg.release).toBeCloseTo(layerAdsr.release as number, 6);
-      } finally {
-        rnd.mockRestore();
-      }
+      // deterministicNoiseMap always returns -1, mapping every getSeededVal to its min.
+      // numLayers = 1 + floor(0) = 1; all ADSR values = their respective minimums.
+      const attrs = generateAudioAttributes(deterministicNoiseMap, 0);
+      const vm = attrs.visualAudioMap!;
+      const layers = vm.layeredWave?.layers ?? [];
+      // With noiseMap always -1 we always get exactly 1 layer
+      expect(layers.length).toBe(1);
+      const layerAdsr = layers[0].adsr!;
+      const avg = vm.averagedADSR!;
+      // Gain-weighted average of a single layer equals that layer's own values
+      expect(avg.attack).toBeCloseTo(layerAdsr.attack as number, 6);
+      expect(avg.decay).toBeCloseTo(layerAdsr.decay as number, 6);
+      expect(avg.sustain).toBeCloseTo(layerAdsr.sustain as number, 6);
+      expect(avg.release).toBeCloseTo(layerAdsr.release as number, 6);
     });
   });
 

--- a/src/systems/spawnSystem.ts
+++ b/src/systems/spawnSystem.ts
@@ -1,6 +1,7 @@
 // ========================================
 // IMPORTS
 // ========================================
+import type { NoiseFunction2D } from 'simplex-noise';
 import type { Vec2 } from '../types/Vec2';
 import type { Robot, AudioAttributes, SynthType, WaveformType } from '../types/Robot';
 import { RobotState } from '../types/Robot';
@@ -10,8 +11,12 @@ import type { LayeredWave, LayerDescriptor } from '../types/layeredAudio';
 import { scheduleRepeat, cancelSchedule } from '../engine/beatClock';
 import { DEV_TUNING } from '../constants';
 import useLocaleStore from '../stores/localeStore';
+import { usePlanetStore } from '../stores/planetStore';
 import type { LocaleSettings } from '../types/locale';
 import { removeRobotWithExit } from './removeSystem';
+import { initRobotIdleCounter } from './idleSystem';
+import { getLocaleNoiseMap } from '../utils/noiseMaps';
+import { getSeededVal } from '../utils/getSeededVal';
 
 // ========================================
 // CONSTANTS
@@ -64,9 +69,9 @@ const WAVEFORMS: WaveformType[] = ['sine', 'square', 'triangle', 'sawtooth'];
 const ADJECTIVES = ['Iron', 'Null', 'Silent', 'Drift', 'Azure', 'Rust', 'Neon', 'Glass', 'Solar', 'Tidal'];
 const NOUNS = ['Drifter', 'Tide', 'Warden', 'Seeker', 'Courier', 'Wisp', 'Beacon', 'Nomad', 'Rover', 'Pilot'];
 
-function generateRobotName(): string {
-  const a = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
-  const n = NOUNS[Math.floor(Math.random() * NOUNS.length)];
+function generateRobotName(noiseMap: NoiseFunction2D, offset: number): string {
+  const a = ADJECTIVES[Math.floor(getSeededVal(noiseMap, 'robot.name.adj', offset, 0, ADJECTIVES.length))];
+  const n = NOUNS[Math.floor(getSeededVal(noiseMap, 'robot.name.noun', offset, 0, NOUNS.length))];
   return `${a} ${n}`;
 }
 
@@ -74,6 +79,15 @@ function generateRobotName(): string {
 // MODULE STATE
 // ========================================
 let spawnScheduleId: string | null = null;
+
+/** Per-locale spawn counters — used as deterministic offset for noise sampling. Not stored in Zustand. */
+const spawnCounters = new Map<string, number>();
+
+function getAndIncrementSpawnCount(localeId: string): number {
+  const count = spawnCounters.get(localeId) ?? 0;
+  spawnCounters.set(localeId, count + 1);
+  return count;
+}
 
 // ========================================
 // EXPORTS
@@ -91,8 +105,16 @@ export function startSpawnScheduler(localeId: string): void {
     return;
   }
 
-  const interval =
-    SPAWN_INTERVAL_MIN + Math.floor(Math.random() * (SPAWN_INTERVAL_MAX - SPAWN_INTERVAL_MIN + 1));
+  const locale = useLocaleStore.getState().getLocaleById(localeId);
+  const planet = locale ? usePlanetStore.getState().planets.find((p) => p.id === locale.planetId) : undefined;
+  const schedulerNoiseMap = locale && planet
+    ? getLocaleNoiseMap(localeId, locale.planetId, planet.name, locale.coordinates.x, locale.coordinates.y)
+    : null;
+  const interval = SPAWN_INTERVAL_MIN + Math.floor(
+    schedulerNoiseMap
+      ? getSeededVal(schedulerNoiseMap, 'spawn.interval', spawnCounters.get(localeId) ?? 0, 0, SPAWN_INTERVAL_MAX - SPAWN_INTERVAL_MIN + 1)
+      : Math.random() * (SPAWN_INTERVAL_MAX - SPAWN_INTERVAL_MIN + 1)
+  );
 
   spawnScheduleId = scheduleRepeat(`${interval}m`, () => {
     spawnRobot(localeId);
@@ -123,30 +145,30 @@ export function stopSpawnScheduler(): void {
  * Robots are invisible here (SVG clips to viewBox) and swim inward on their
  * first idle tick, creating a natural "swimming on-screen" entrance.
  */
-export function generateSpawnPosition(): Vec2 {
-  const edge = Math.floor(Math.random() * 4); // 0=top, 1=right, 2=bottom, 3=left
+export function generateSpawnPosition(noiseMap: NoiseFunction2D, offset: number): Vec2 {
+  const edge = Math.floor(getSeededVal(noiseMap, 'spawn.pos.edge', offset, 0, 4)); // 0=top, 1=right, 2=bottom, 3=left
 
   switch (edge) {
     case 0: // Top edge — spawn above the scene
       return {
-        x: Math.random() * WORLD_WIDTH,
-        y: -OFFSCREEN_OFFSET - Math.random() * 50,
+        x: getSeededVal(noiseMap, 'spawn.pos.x', offset, 0, WORLD_WIDTH),
+        y: -OFFSCREEN_OFFSET - getSeededVal(noiseMap, 'spawn.pos.y', offset, 0, 50),
       };
     case 1: // Right edge — spawn to the right of the scene
       return {
-        x: WORLD_WIDTH + OFFSCREEN_OFFSET + Math.random() * 50,
-        y: Math.random() * WORLD_HEIGHT,
+        x: WORLD_WIDTH + OFFSCREEN_OFFSET + getSeededVal(noiseMap, 'spawn.pos.x', offset, 0, 50),
+        y: getSeededVal(noiseMap, 'spawn.pos.y', offset, 0, WORLD_HEIGHT),
       };
     case 2: // Bottom edge — spawn below the scene
       return {
-        x: Math.random() * WORLD_WIDTH,
-        y: WORLD_HEIGHT + OFFSCREEN_OFFSET + Math.random() * 50,
+        x: getSeededVal(noiseMap, 'spawn.pos.x', offset, 0, WORLD_WIDTH),
+        y: WORLD_HEIGHT + OFFSCREEN_OFFSET + getSeededVal(noiseMap, 'spawn.pos.y', offset, 0, 50),
       };
     case 3: // Left edge — spawn to the left of the scene
     default:
       return {
-        x: -OFFSCREEN_OFFSET - Math.random() * 50,
-        y: Math.random() * WORLD_HEIGHT,
+        x: -OFFSCREEN_OFFSET - getSeededVal(noiseMap, 'spawn.pos.x', offset, 0, 50),
+        y: getSeededVal(noiseMap, 'spawn.pos.y', offset, 0, WORLD_HEIGHT),
       };
   }
 }
@@ -155,29 +177,26 @@ export function generateSpawnPosition(): Vec2 {
  * Generate random audio attributes
  * Controls both sound synthesis and visual appearance
  */
-export function generateAudioAttributes(): AudioAttributes {
-  // Random synth type
-  const synthType = SYNTH_TYPES[Math.floor(Math.random() * SYNTH_TYPES.length)];
+export function generateAudioAttributes(noiseMap: NoiseFunction2D, offset: number): AudioAttributes {
+  // Seeded synth type
+  const synthType = SYNTH_TYPES[Math.floor(getSeededVal(noiseMap, 'robot.audio.synthType', offset, 0, SYNTH_TYPES.length))];
 
-  // Random ADSR envelope
+  // Seeded ADSR envelope
   const adsr = {
-    attack: ATTACK_RANGE.min + Math.random() * (ATTACK_RANGE.max - ATTACK_RANGE.min),
-    decay: DECAY_RANGE.min + Math.random() * (DECAY_RANGE.max - DECAY_RANGE.min),
-    sustain: SUSTAIN_RANGE.min + Math.random() * (SUSTAIN_RANGE.max - SUSTAIN_RANGE.min),
-    release: RELEASE_RANGE.min + Math.random() * (RELEASE_RANGE.max - RELEASE_RANGE.min),
+    attack: getSeededVal(noiseMap, 'robot.audio.attack', offset, ATTACK_RANGE.min, ATTACK_RANGE.max),
+    decay: getSeededVal(noiseMap, 'robot.audio.decay', offset, DECAY_RANGE.min, DECAY_RANGE.max),
+    sustain: getSeededVal(noiseMap, 'robot.audio.sustain', offset, SUSTAIN_RANGE.min, SUSTAIN_RANGE.max),
+    release: getSeededVal(noiseMap, 'robot.audio.release', offset, RELEASE_RANGE.min, RELEASE_RANGE.max),
   };
 
-  // Random pitch range (determines visual scale)
-  const pitchRange = PITCH_RANGES[Math.floor(Math.random() * PITCH_RANGES.length)];
+  // Seeded pitch range (determines visual scale)
+  const pitchRange = PITCH_RANGES[Math.floor(getSeededVal(noiseMap, 'robot.audio.pitchRange', offset, 0, PITCH_RANGES.length))];
 
-  // Random filter frequency (determines detail level)
-  const filterFreq =
-    FILTER_FREQ_RANGE.min +
-    Math.random() * (FILTER_FREQ_RANGE.max - FILTER_FREQ_RANGE.min);
+  // Seeded filter frequency (determines detail level)
+  const filterFreq = getSeededVal(noiseMap, 'robot.audio.filterFreq', offset, FILTER_FREQ_RANGE.min, FILTER_FREQ_RANGE.max);
 
-
-  // Random waveform — evenly distributed (~25% each)
-  const waveform = WAVEFORMS[Math.floor(Math.random() * WAVEFORMS.length)];
+  // Seeded waveform — evenly distributed (~25% each)
+  const waveform = WAVEFORMS[Math.floor(getSeededVal(noiseMap, 'robot.audio.waveform', offset, 0, WAVEFORMS.length))];
 
   // Derive a compact visualAudioMap to store on the robot at spawn time.
   // ---
@@ -189,19 +208,20 @@ export function generateAudioAttributes(): AudioAttributes {
   // If you change the mapping, update docs and robotVisualMapper accordingly.
   const clamp = (v: number) => Math.max(0, Math.min(1, v));
 
-  const numLayers = 1 + Math.floor(Math.random() * MAX_LAYERS); // 1..MAX_LAYERS
+  const numLayers = 1 + Math.floor(getSeededVal(noiseMap, 'robot.audio.numLayers', offset, 0, MAX_LAYERS)); // 1..MAX_LAYERS
   const layers: LayeredWave['layers'] = [];
   for (let i = 0; i < numLayers; i++) {
-    const isNoise = Math.random() < 0.18; // small chance of noise layer
+    const layerOffset = offset * 10 + i;
+    const isNoise = getSeededVal(noiseMap, 'robot.audio.layer.isNoise', layerOffset, 0, 1) < 0.18;
     const layerWave: LayerDescriptor = {
-      type: isNoise ? 'noise' : WAVEFORMS[Math.floor(Math.random() * WAVEFORMS.length)],
-      gain: 0.2 + Math.random() * 1.0, // 0.2 .. 1.2
-      detune: (Math.random() - 0.5) * 4, // -20 .. +20 cents
+      type: isNoise ? 'noise' : WAVEFORMS[Math.floor(getSeededVal(noiseMap, 'robot.audio.layer.waveform', layerOffset, 0, WAVEFORMS.length))],
+      gain: getSeededVal(noiseMap, 'robot.audio.layer.gain', layerOffset, 0.2, 1.2),
+      detune: getSeededVal(noiseMap, 'robot.audio.layer.detune', layerOffset, -2, 2),
       adsr: {
-        attack: ATTACK_RANGE.min + Math.random() * (ATTACK_RANGE.max - ATTACK_RANGE.min),
-        decay: DECAY_RANGE.min + Math.random() * (DECAY_RANGE.max - DECAY_RANGE.min),
-        sustain: SUSTAIN_RANGE.min + Math.random() * (SUSTAIN_RANGE.max - SUSTAIN_RANGE.min),
-        release: RELEASE_RANGE.min + Math.random() * (RELEASE_RANGE.max - RELEASE_RANGE.min),
+        attack: getSeededVal(noiseMap, 'robot.audio.layer.attack', layerOffset, ATTACK_RANGE.min, ATTACK_RANGE.max),
+        decay: getSeededVal(noiseMap, 'robot.audio.layer.decay', layerOffset, DECAY_RANGE.min, DECAY_RANGE.max),
+        sustain: getSeededVal(noiseMap, 'robot.audio.layer.sustain', layerOffset, SUSTAIN_RANGE.min, SUSTAIN_RANGE.max),
+        release: getSeededVal(noiseMap, 'robot.audio.layer.release', layerOffset, RELEASE_RANGE.min, RELEASE_RANGE.max),
       },
     };
     layers.push(layerWave);
@@ -263,7 +283,7 @@ export function generateAudioAttributes(): AudioAttributes {
   };
 
   // Phase: 0..360 degrees (used for oscillator phase)
-  const phase = Math.floor(Math.random() * 361);
+  const phase = Math.floor(getSeededVal(noiseMap, 'robot.audio.phase', offset, 0, 361));
   // Detune: default 0 cents (fine pitch adjustment)
   const detune = 0;
 
@@ -315,27 +335,53 @@ export function spawnRobot(localeId: string): void {
     return;
   }
 
+  // Resolve locale noise map for deterministic attribute generation
+  const planet = locale ? usePlanetStore.getState().planets.find((p) => p.id === locale.planetId) : undefined;
+  const noiseMap = locale && planet
+    ? getLocaleNoiseMap(localeId, locale.planetId, planet.name, locale.coordinates.x, locale.coordinates.y)
+    : null;
+
+  // Monotonically incrementing offset for this locale — ensures each robot is distinct
+  const spawnCount = getAndIncrementSpawnCount(localeId);
+
   // Generate audio attributes first so octaveRange can be derived and passed to melody generator
-  const audioAttributes = generateAudioAttributes();
+  const audioAttributes = noiseMap
+    ? generateAudioAttributes(noiseMap, spawnCount)
+    : generateAudioAttributes({
+      // fallback: create a trivial noise-like map from Math.random
+      // This path is only hit if locale/planet data is missing (should not happen in production)
+    } as unknown as NoiseFunction2D, spawnCount);
   const octaveRange = pickOctaveRange(audioAttributes.pitchRange);
+
+  // Seeded melody: each rand() call uses a unique offset within this robot's spawn slot
+  let melodyCallIndex = 0;
+  const melodyRand = noiseMap
+    ? () => getSeededVal(noiseMap, 'melody.rand', spawnCount * 100 + melodyCallIndex++)
+    : Math.random;
 
   const robot: Robot = {
     id: crypto.randomUUID(),
-    name: generateRobotName(),
+    name: noiseMap ? generateRobotName(noiseMap, spawnCount) : generateRobotName({ x: 0, y: 0 } as unknown as NoiseFunction2D, spawnCount),
     state: RobotState.Idle,
-    position: generateSpawnPosition(),
+    position: noiseMap ? generateSpawnPosition(noiseMap, spawnCount) : generateSpawnPosition({ x: 0, y: 0 } as unknown as NoiseFunction2D, spawnCount),
     destination: null,
     direction: 'right', // Default facing direction (will be updated by idleSystem)
-    melody: generateMelodyForRobot({ octaveRange }),
+    melody: generateMelodyForRobot({ octaveRange, rand: melodyRand }),
     audioAttributes,
     octaveRange,
-    masterVolume: MASTER_VOLUME_MIN + Math.random() * (MASTER_VOLUME_MAX - MASTER_VOLUME_MIN),
+    masterVolume: noiseMap
+      ? getSeededVal(noiseMap, 'robot.masterVolume', spawnCount, MASTER_VOLUME_MIN, MASTER_VOLUME_MAX)
+      : MASTER_VOLUME_MIN + Math.random() * (MASTER_VOLUME_MAX - MASTER_VOLUME_MIN),
     createdAt: Date.now(),
     persistent: true,
   };
 
   // Add to locale store
   useLocaleStore.getState().addRobot(localeId, robot);
+
+  // Seed the idle counter to this robot's spawn index so its noise-sampled
+  // destinations are phase-shifted away from other robots in the same locale.
+  initRobotIdleCounter(robot.id, spawnCount);
 
   // Register melody with AudioEngine
   // Unregister first to guard against duplicate entries if robot id is reused.


### PR DESCRIPTION
- Replace Math.random() usage in spawn, idle, and interaction systems with getSeededVal(...) backed by per-locale noise maps.
- Seed melody generation by passing a deterministic rand lambda to generateMelodyForRobot.
- Add per-locale spawnCounters and per-robot idleMoveCounters (seeded at spawn) so each robot follows a deterministic, unique noise sequence.
- Ensure factory-created robots have deterministic audioAttributes when a locale is provided; add safe fallback when not.
- Fix idle behavior: robots now pick distinct seeded destinations (no freezing or conga-line correlation) and counters cleaned up on removal.
- Update tests to pass mock NoiseFunction2D and reflect the new APIs.

Closes #264