### PR TITLE
Build RobotAudioTab with solo/mute/highlight radio group, density

### DIFF
--- a/src/components/panels/screen/console/RobotAudioTab.css
+++ b/src/components/panels/screen/console/RobotAudioTab.css
@@ -1,0 +1,197 @@
+.rat-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 4px 0;
+}
+
+/* ── Row layouts ──────────────────────────────── */
+
+.rat-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.rat-row--column {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.rat-row-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+/* ── Label & value ────────────────────────────── */
+
+.rat-label {
+  font-size: 0.85rem;
+  color: var(--text-muted, #aab3bf);
+  white-space: nowrap;
+  min-width: 90px;
+}
+
+.rat-value {
+  font-size: 0.85rem;
+  color: var(--accent, #8be);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Toggle group (audio mode) ────────────────── */
+
+.rat-toggle-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.rat-toggle-item {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border, #444);
+  background: var(--surface, #111);
+  color: var(--text-muted, #aab3bf);
+  font-size: 0.8rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rat-toggle-item[data-state='on'] {
+  background: var(--surface-2, rgba(136, 187, 238, 0.12));
+  border-color: var(--accent, #8be);
+  color: var(--accent, #8be);
+}
+
+/* ── Slider ───────────────────────────────────── */
+
+.rat-slider {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 20px;
+  touch-action: none;
+  user-select: none;
+}
+
+.rat-slider-track {
+  background: var(--surface-2, rgba(255, 255, 255, 0.08));
+  position: relative;
+  flex-grow: 1;
+  border-radius: 9999px;
+  height: 4px;
+}
+
+.rat-slider-range {
+  position: absolute;
+  background: var(--accent, #8be);
+  border-radius: 9999px;
+  height: 100%;
+}
+
+.rat-slider-thumb {
+  display: block;
+  width: 18px;
+  height: 18px;
+  background: var(--accent, #8be);
+  border-radius: 50%;
+  cursor: pointer;
+  /* Visually 18px but logical touch target via padding trick */
+  box-shadow: 0 0 0 3px rgba(136, 187, 238, 0.2);
+  min-width: 44px;
+  min-height: 44px;
+  /* Override to actual visual size; touch area is provided by the slider hit area */
+  width: 18px;
+  height: 18px;
+}
+
+.rat-slider-thumb:focus-visible {
+  outline: 2px solid var(--accent, #8be);
+  outline-offset: 2px;
+}
+
+/* ── Button ───────────────────────────────────── */
+
+.rat-btn {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 8px 14px;
+  border-radius: 6px;
+  background: var(--accent, #1e90ff);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.rat-btn--secondary {
+  background: var(--surface-2, rgba(255, 255, 255, 0.06));
+  color: var(--text, #e6eef8);
+  border: 1px solid var(--border, #444);
+}
+
+.rat-btn:hover {
+  opacity: 0.9;
+}
+
+/* ── AlertDialog ──────────────────────────────── */
+
+.rat-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 100;
+}
+
+.rat-dialog-content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--surface, #1a1d21);
+  border: 1px solid var(--border, #333);
+  border-radius: 10px;
+  padding: 24px;
+  min-width: 280px;
+  max-width: 400px;
+  z-index: 101;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.rat-dialog-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text, #e6eef8);
+  margin: 0;
+}
+
+.rat-dialog-description {
+  font-size: 0.875rem;
+  color: var(--text-muted, #aab3bf);
+  margin: 0;
+}
+
+.rat-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+/* ── Empty state ──────────────────────────────── */
+
+.rat-empty {
+  color: var(--text-muted, #aab3bf);
+  font-style: italic;
+  font-size: 0.875rem;
+}

--- a/src/components/panels/screen/console/RobotAudioTab.tsx
+++ b/src/components/panels/screen/console/RobotAudioTab.tsx
@@ -1,0 +1,229 @@
+// ========================================
+// IMPORTS
+// ========================================
+import * as ToggleGroup from '@radix-ui/react-toggle-group';
+import * as Slider from '@radix-ui/react-slider';
+import * as AlertDialog from '@radix-ui/react-alert-dialog';
+
+import { getActiveLocaleId } from '@/utils/localeHelpers';
+import { useLocaleStore } from '@/stores/localeStore';
+import { AudioEngine } from '@/engine/AudioEngine';
+import { generateMelodyForRobot } from '@/engine/melodyGenerator';
+import type { Robot } from '@/types/Robot';
+
+import './RobotAudioTab.css';
+
+// ========================================
+// TYPES
+// ========================================
+type AudioMode = 'none' | 'solo' | 'mute' | 'highlight';
+
+// ========================================
+// CONSTANTS
+// ========================================
+const DENSITY_MIN = 4;
+const DENSITY_MAX = 12;
+const MOTIF_MIN = 1;
+const MOTIF_MAX = 16;
+const OCTAVE_MIN = 1;
+const OCTAVE_MAX = 7;
+
+const AUDIO_MODES: AudioMode[] = ['none', 'solo', 'mute', 'highlight'];
+
+// ========================================
+// HELPERS
+// ========================================
+
+/**
+ * Regenerate a robot's melody from its current attributes and register it with AudioEngine.
+ * Must run outside the Transport tick — queueMicrotask ensures this.
+ */
+function regenerateMelody(robot: Robot, localeId: string): void {
+  const newMelody = generateMelodyForRobot({
+    events: robot.rhythmicDensity ?? 6,
+    octaveRange: robot.octaveRange,
+  });
+  queueMicrotask(() => {
+    useLocaleStore.getState().updateRobot(localeId, robot.id, { melody: newMelody });
+    AudioEngine.registerRobotMelody(robot.id, newMelody);
+  });
+}
+
+// ========================================
+// COMPONENT
+// ========================================
+
+interface RobotAudioTabProps {
+  robot: Robot;
+}
+
+export function RobotAudioTab({ robot }: RobotAudioTabProps) {
+  const localeId = getActiveLocaleId();
+
+  if (!localeId) {
+    return <div className="rat-empty">No active locale.</div>;
+  }
+
+  const audioMode = (robot.audioMode ?? 'none') as AudioMode;
+  const rhythmicDensity = robot.rhythmicDensity ?? 6;
+  const rhythmicMotifLength = robot.rhythmicMotifLength ?? 8;
+  const [octMin, octMax] = robot.octaveRange;
+
+  const handleAudioModeChange = (value: string) => {
+    useLocaleStore.getState().updateRobot(localeId, robot.id, { audioMode: value as AudioMode });
+  };
+
+  const handleDensityChange = (values: number[]) => {
+    const density = values[0];
+    useLocaleStore.getState().updateRobot(localeId, robot.id, { rhythmicDensity: density });
+    regenerateMelody({ ...robot, rhythmicDensity: density }, localeId);
+  };
+
+  const handleMotifLengthChange = (values: number[]) => {
+    const length = values[0];
+    useLocaleStore.getState().updateRobot(localeId, robot.id, { rhythmicMotifLength: length });
+    regenerateMelody({ ...robot, rhythmicMotifLength: length }, localeId);
+  };
+
+  const handleOctaveRangeChange = (values: number[]) => {
+    const newRange: [number, number] = [values[0], values[1]];
+    useLocaleStore.getState().updateRobot(localeId, robot.id, { octaveRange: newRange });
+  };
+
+  const handleConfirmNewMelody = () => {
+    regenerateMelody(robot, localeId);
+  };
+
+  return (
+    <div className="rat-container">
+
+      {/* ── Audio Mode ──────────────────────────── */}
+      <div className="rat-row">
+        <span className="rat-label">Audio Mode</span>
+        <ToggleGroup.Root
+          type="single"
+          className="rat-toggle-group"
+          value={audioMode}
+          onValueChange={(value) => { if (value) handleAudioModeChange(value); }}
+          aria-label="Audio mode"
+        >
+          {AUDIO_MODES.map((mode) => (
+            <ToggleGroup.Item
+              key={mode}
+              className="rat-toggle-item"
+              value={mode}
+              aria-label={mode.charAt(0).toUpperCase() + mode.slice(1)}
+            >
+              {mode.charAt(0).toUpperCase() + mode.slice(1)}
+            </ToggleGroup.Item>
+          ))}
+        </ToggleGroup.Root>
+      </div>
+
+      {/* ── Rhythmic Density ────────────────────── */}
+      <div className="rat-row rat-row--column">
+        <div className="rat-row-header">
+          <span className="rat-label">Density</span>
+          <span className="rat-value">{rhythmicDensity}</span>
+        </div>
+        <Slider.Root
+          className="rat-slider"
+          min={DENSITY_MIN}
+          max={DENSITY_MAX}
+          step={1}
+          value={[rhythmicDensity]}
+          onValueChange={handleDensityChange}
+          aria-label="Rhythmic density"
+        >
+          <Slider.Track className="rat-slider-track">
+            <Slider.Range className="rat-slider-range" />
+          </Slider.Track>
+          <Slider.Thumb className="rat-slider-thumb" aria-label="Density" />
+        </Slider.Root>
+      </div>
+
+      {/* ── Motif Length ────────────────────────── */}
+      <div className="rat-row rat-row--column">
+        <div className="rat-row-header">
+          <span className="rat-label">Motif Length</span>
+          <span className="rat-value">{rhythmicMotifLength}</span>
+        </div>
+        <Slider.Root
+          className="rat-slider"
+          min={MOTIF_MIN}
+          max={MOTIF_MAX}
+          step={1}
+          value={[rhythmicMotifLength]}
+          onValueChange={handleMotifLengthChange}
+          aria-label="Motif length"
+        >
+          <Slider.Track className="rat-slider-track">
+            <Slider.Range className="rat-slider-range" />
+          </Slider.Track>
+          <Slider.Thumb className="rat-slider-thumb" aria-label="Motif length" />
+        </Slider.Root>
+      </div>
+
+      {/* ── Octave Range ────────────────────────── */}
+      <div className="rat-row rat-row--column">
+        <div className="rat-row-header">
+          <span className="rat-label">Octave Range</span>
+          <span className="rat-value">{octMin}–{octMax}</span>
+        </div>
+        <Slider.Root
+          className="rat-slider"
+          min={OCTAVE_MIN}
+          max={OCTAVE_MAX}
+          step={1}
+          value={[octMin, octMax]}
+          minStepsBetweenThumbs={1}
+          onValueChange={handleOctaveRangeChange}
+          aria-label="Octave range"
+        >
+          <Slider.Track className="rat-slider-track">
+            <Slider.Range className="rat-slider-range" />
+          </Slider.Track>
+          <Slider.Thumb className="rat-slider-thumb" aria-label="Minimum octave" />
+          <Slider.Thumb className="rat-slider-thumb" aria-label="Maximum octave" />
+        </Slider.Root>
+      </div>
+
+      {/* ── New Melody ──────────────────────────── */}
+      <div className="rat-row">
+        <AlertDialog.Root>
+          <AlertDialog.Trigger asChild>
+            <button className="rat-btn" type="button">
+              New Melody
+            </button>
+          </AlertDialog.Trigger>
+          <AlertDialog.Portal>
+            <AlertDialog.Overlay className="rat-dialog-overlay" />
+            <AlertDialog.Content className="rat-dialog-content">
+              <AlertDialog.Title className="rat-dialog-title">
+                Regenerate melody?
+              </AlertDialog.Title>
+              <AlertDialog.Description className="rat-dialog-description">
+                The current melody will be replaced.
+              </AlertDialog.Description>
+              <div className="rat-dialog-actions">
+                <AlertDialog.Cancel asChild>
+                  <button className="rat-btn rat-btn--secondary" type="button">
+                    Cancel
+                  </button>
+                </AlertDialog.Cancel>
+                <AlertDialog.Action asChild>
+                  <button className="rat-btn" type="button" onClick={handleConfirmNewMelody}>
+                    Regenerate
+                  </button>
+                </AlertDialog.Action>
+              </div>
+            </AlertDialog.Content>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>
+      </div>
+
+    </div>
+  );
+}
+
+export default RobotAudioTab;

--- a/src/components/panels/screen/console/RobotEditorTab.tsx
+++ b/src/components/panels/screen/console/RobotEditorTab.tsx
@@ -1,6 +1,7 @@
 import * as Tabs from '@radix-ui/react-tabs';
 
 import RobotMetaTab from './RobotMetaTab.tsx';
+import { RobotAudioTab } from './RobotAudioTab.tsx';
 import type { Robot } from '@/types/Robot';
 import { getActiveLocaleId } from '@/utils/localeHelpers';
 import { useUIStore } from '@/stores/uiStore';
@@ -52,7 +53,7 @@ export function RobotEditorTab() {
           </Tabs.Content>
 
           <Tabs.Content value="audio" className="tab-content">
-            {robot ? <RobotAudioPanel robot={robot} /> : <div className="empty">Robot not found</div>}
+            {robot ? <RobotAudioTab robot={robot} /> : <div className="empty">Robot not found</div>}
           </Tabs.Content>
 
           <Tabs.Content value="oscillators" className="tab-content">
@@ -65,15 +66,7 @@ export function RobotEditorTab() {
 }
 
 // Robot meta panel is implemented in its own file: RobotMetaTab.tsx
-
-function RobotAudioPanel({ robot }: { robot: Robot }) {
-  return (
-    <div className="robot-audio-panel">
-      <p>Audio attributes are displayed here (placeholder).</p>
-      <pre className="robot-audio-pre">{JSON.stringify(robot.audioAttributes, null, 2)}</pre>
-    </div>
-  );
-}
+// Robot audio panel is implemented in its own file: RobotAudioTab.tsx
 
 function RobotOscillatorsPanel({ robot }: { robot: Robot }) {
   return (

--- a/src/components/panels/screen/console/RobotMetaTab.tsx
+++ b/src/components/panels/screen/console/RobotMetaTab.tsx
@@ -102,17 +102,18 @@ export default function RobotMetaTab() {
     if (target.melody) updates.melody = target.melody;
     if (target.octaveRange) updates.octaveRange = target.octaveRange;
     if (typeof target.masterVolume === 'number') updates.masterVolume = target.masterVolume;
-    // Optional fields (may not exist yet) — copy if present on the target
-    const optFields = ['rhythmicDensity', 'rhythmicMotifLength', 'noteVariance', 'audioMode'];
-    optFields.forEach((f) => {
-      if ((target as any)[f] !== undefined) (updates as any)[f] = (target as any)[f];
-    });
+    // Optional fields — copy if present on the target
+    // Generic helper is required so TypeScript can correlate key K between src and dst.
+    const copyIfPresent = <K extends 'rhythmicDensity' | 'rhythmicMotifLength' | 'audioMode'>(
+      src: Robot, dst: Partial<Robot>, k: K
+    ) => { if (src[k] !== undefined) dst[k] = src[k]; };
+    const optFields = ['rhythmicDensity', 'rhythmicMotifLength', 'audioMode'] as const;
+    for (const f of optFields) copyIfPresent(target, updates, f);
 
     // Backup current values for undo
-    const backup: Partial<Robot> = {};
-    Object.keys(updates).forEach((k) => {
-      (backup as any)[k] = (robot as any)[k];
-    });
+    const backup = Object.fromEntries(
+      (Object.keys(updates) as Array<keyof Robot>).map((k) => [k, robot[k]])
+    ) as Partial<Robot>;
     setLastBackup(backup);
 
     // Apply updates to the selected robot
@@ -122,8 +123,8 @@ export default function RobotMetaTab() {
     queueMicrotask(() => {
       try {
         AudioEngine.unregisterRobotMelody(robot.id);
-        if (updates.melody && (updates.melody as any).length > 0) {
-          AudioEngine.registerRobotMelody(robot.id, updates.melody as any);
+        if (updates.melody && updates.melody.length > 0) {
+          AudioEngine.registerRobotMelody(robot.id, updates.melody);
         }
       } catch (err) {
         console.warn('[RobotMetaTab] AudioEngine melody update error', err);
@@ -136,7 +137,7 @@ export default function RobotMetaTab() {
         const adsr = (updates.audioAttributes && updates.audioAttributes.adsr) ?? robot.audioAttributes?.adsr;
         const phase = (updates.audioAttributes && updates.audioAttributes.phase) ?? robot.audioAttributes?.phase;
         const detune = (updates.audioAttributes && updates.audioAttributes.detune) ?? robot.audioAttributes?.detune;
-        AudioEngine.reserveVoice(robot.id, synthType as any, waveform as any, adsr as any, phase as any, detune as any);
+        AudioEngine.reserveVoice(robot.id, synthType, waveform, adsr, phase, detune);
       } catch (err) {
         console.warn('[RobotMetaTab] AudioEngine voice re-reservation error', err);
       }
@@ -153,8 +154,8 @@ export default function RobotMetaTab() {
     queueMicrotask(() => {
       try {
         AudioEngine.unregisterRobotMelody(robot.id);
-        if ((lastBackup as any).melody && (lastBackup as any).melody.length > 0) {
-          AudioEngine.registerRobotMelody(robot.id, (lastBackup as any).melody as any);
+        if (lastBackup.melody && lastBackup.melody.length > 0) {
+          AudioEngine.registerRobotMelody(robot.id, lastBackup.melody);
         }
       } catch (err) {
         console.warn('[RobotMetaTab] AudioEngine melody undo error', err);
@@ -162,13 +163,13 @@ export default function RobotMetaTab() {
 
       try {
         AudioEngine.releaseVoice(robot.id);
-        const audioAttr = (lastBackup as any).audioAttributes ?? robot.audioAttributes;
+        const audioAttr = lastBackup.audioAttributes ?? robot.audioAttributes;
         const synthType = audioAttr?.synthType ?? 'default';
         const waveform = audioAttr?.waveform;
         const adsr = audioAttr?.adsr;
         const phase = audioAttr?.phase;
         const detune = audioAttr?.detune;
-        AudioEngine.reserveVoice(robot.id, synthType as any, waveform as any, adsr as any, phase as any, detune as any);
+        AudioEngine.reserveVoice(robot.id, synthType, waveform, adsr, phase, detune);
       } catch (err) {
         console.warn('[RobotMetaTab] AudioEngine voice re-reservation undo error', err);
       }

--- a/src/systems/spawnSystem.ts
+++ b/src/systems/spawnSystem.ts
@@ -365,6 +365,8 @@ export function spawnRobot(localeId: string): void {
     ? () => getSeededVal(noiseMap, 'melody.rand', spawnCount * 100 + melodyCallIndex++)
     : Math.random;
 
+  const spawnMelody = generateMelodyForRobot({ octaveRange, rand: melodyRand });
+
   const robot: Robot = {
     id: crypto.randomUUID(),
     name: noiseMap ? generateRobotName(noiseMap, spawnCount) : generateRobotName({ x: 0, y: 0 } as unknown as NoiseFunction2D, spawnCount),
@@ -372,9 +374,12 @@ export function spawnRobot(localeId: string): void {
     position: noiseMap ? generateSpawnPosition(noiseMap, spawnCount) : generateSpawnPosition({ x: 0, y: 0 } as unknown as NoiseFunction2D, spawnCount),
     destination: null,
     direction: 'right', // Default facing direction (will be updated by idleSystem)
-    melody: generateMelodyForRobot({ octaveRange, rand: melodyRand }),
+    melody: spawnMelody,
     audioAttributes,
     octaveRange,
+    audioMode: 'none',
+    rhythmicDensity: spawnMelody.length,
+    rhythmicMotifLength: 8,
     masterVolume: noiseMap
       ? getSeededVal(noiseMap, 'robot.masterVolume', spawnCount, MASTER_VOLUME_MIN, MASTER_VOLUME_MAX)
       : MASTER_VOLUME_MIN + Math.random() * (MASTER_VOLUME_MAX - MASTER_VOLUME_MIN),

--- a/src/types/Robot.ts
+++ b/src/types/Robot.ts
@@ -103,6 +103,24 @@ export interface Robot {
   persists?: boolean;
   /** Optional link target for future follow/sync features. */
   linkedRobotId?: string | null;
+  /**
+   * Solo/mute/highlight mode set by the Robot Audio editor.
+   * AudioEngine applies solo/mute on next scheduled note.
+   * 'highlight' is visual-only (no audio change).
+   * Default: 'none'
+   */
+  audioMode?: 'none' | 'solo' | 'mute' | 'highlight';
+  /**
+   * Number of melody events (4–12). Maps to `events` in generateMelodyForRobot().
+   * Default: derived from initial melody length at spawn.
+   */
+  rhythmicDensity?: number;
+  /**
+   * Motif length in 16th-note subdivisions (1–16).
+   * Stored for the melody editor; passed to generator when supported.
+   * Default: 8
+   */
+  rhythmicMotifLength?: number;
   // Note: Visual appearance (shape, colors, scale, detail level) is derived
   // from audioAttributes and NOT stored in state - calculated at render time
 }


### PR DESCRIPTION
and motif-length sliders, dual-thumb octave range slider, and New Melody action with AlertDialog confirmation.

Add audioMode, rhythmicDensity, rhythmicMotifLength to Robot interface and seed defaults at spawn. octaveMin/octaveMax folded into existing octaveRange tuple.

Closes #186
