### PR TITLE
feat(types): add robot audio fields and spawn defaults

### DIFF
--- a/src/components/panels/screen/console/RobotMetaTab.tsx
+++ b/src/components/panels/screen/console/RobotMetaTab.tsx
@@ -103,16 +103,21 @@ export default function RobotMetaTab() {
     if (target.octaveRange) updates.octaveRange = target.octaveRange;
     if (typeof target.masterVolume === 'number') updates.masterVolume = target.masterVolume;
     // Optional fields (may not exist yet) — copy if present on the target
-    const optFields = ['rhythmicDensity', 'rhythmicMotifLength', 'noteVariance', 'audioMode'];
-    optFields.forEach((f) => {
-      if ((target as any)[f] !== undefined) (updates as any)[f] = (target as any)[f];
-    });
+    const copyIfPresent = <K extends 'rhythmicDensity' | 'rhythmicMotifLength' | 'noteVariance' | 'audioMode'>(
+      src: Robot,
+      dst: Partial<Robot>,
+      key: K
+    ) => {
+      if (src[key] !== undefined) dst[key] = src[key];
+    };
+
+    const optFields = ['rhythmicDensity', 'rhythmicMotifLength', 'noteVariance', 'audioMode'] as const;
+    for (const f of optFields) copyIfPresent(target, updates, f);
 
     // Backup current values for undo
-    const backup: Partial<Robot> = {};
-    Object.keys(updates).forEach((k) => {
-      (backup as any)[k] = (robot as any)[k];
-    });
+    const backup = Object.fromEntries(
+      (Object.keys(updates) as Array<keyof Robot>).map((k) => [k, robot[k]])
+    ) as Partial<Robot>;
     setLastBackup(backup);
 
     // Apply updates to the selected robot
@@ -122,8 +127,8 @@ export default function RobotMetaTab() {
     queueMicrotask(() => {
       try {
         AudioEngine.unregisterRobotMelody(robot.id);
-        if (updates.melody && (updates.melody as any).length > 0) {
-          AudioEngine.registerRobotMelody(robot.id, updates.melody as any);
+        if (updates.melody && updates.melody.length > 0) {
+          AudioEngine.registerRobotMelody(robot.id, updates.melody);
         }
       } catch (err) {
         console.warn('[RobotMetaTab] AudioEngine melody update error', err);
@@ -136,7 +141,7 @@ export default function RobotMetaTab() {
         const adsr = (updates.audioAttributes && updates.audioAttributes.adsr) ?? robot.audioAttributes?.adsr;
         const phase = (updates.audioAttributes && updates.audioAttributes.phase) ?? robot.audioAttributes?.phase;
         const detune = (updates.audioAttributes && updates.audioAttributes.detune) ?? robot.audioAttributes?.detune;
-        AudioEngine.reserveVoice(robot.id, synthType as any, waveform as any, adsr as any, phase as any, detune as any);
+        AudioEngine.reserveVoice(robot.id, synthType, waveform, adsr, phase, detune);
       } catch (err) {
         console.warn('[RobotMetaTab] AudioEngine voice re-reservation error', err);
       }
@@ -153,8 +158,8 @@ export default function RobotMetaTab() {
     queueMicrotask(() => {
       try {
         AudioEngine.unregisterRobotMelody(robot.id);
-        if ((lastBackup as any).melody && (lastBackup as any).melody.length > 0) {
-          AudioEngine.registerRobotMelody(robot.id, (lastBackup as any).melody as any);
+        if (lastBackup.melody && lastBackup.melody.length > 0) {
+          AudioEngine.registerRobotMelody(robot.id, lastBackup.melody);
         }
       } catch (err) {
         console.warn('[RobotMetaTab] AudioEngine melody undo error', err);
@@ -162,13 +167,13 @@ export default function RobotMetaTab() {
 
       try {
         AudioEngine.releaseVoice(robot.id);
-        const audioAttr = (lastBackup as any).audioAttributes ?? robot.audioAttributes;
+        const audioAttr = lastBackup.audioAttributes ?? robot.audioAttributes;
         const synthType = audioAttr?.synthType ?? 'default';
         const waveform = audioAttr?.waveform;
         const adsr = audioAttr?.adsr;
         const phase = audioAttr?.phase;
         const detune = audioAttr?.detune;
-        AudioEngine.reserveVoice(robot.id, synthType as any, waveform as any, adsr as any, phase as any, detune as any);
+        AudioEngine.reserveVoice(robot.id, synthType, waveform, adsr, phase, detune);
       } catch (err) {
         console.warn('[RobotMetaTab] AudioEngine voice re-reservation undo error', err);
       }

--- a/src/systems/spawnSystem.ts
+++ b/src/systems/spawnSystem.ts
@@ -364,6 +364,7 @@ export function spawnRobot(localeId: string): void {
   const melodyRand = noiseMap
     ? () => getSeededVal(noiseMap, 'melody.rand', spawnCount * 100 + melodyCallIndex++)
     : Math.random;
+  const spawnMelody = generateMelodyForRobot({ octaveRange, rand: melodyRand });
 
   const robot: Robot = {
     id: crypto.randomUUID(),
@@ -372,9 +373,13 @@ export function spawnRobot(localeId: string): void {
     position: noiseMap ? generateSpawnPosition(noiseMap, spawnCount) : generateSpawnPosition({ x: 0, y: 0 } as unknown as NoiseFunction2D, spawnCount),
     destination: null,
     direction: 'right', // Default facing direction (will be updated by idleSystem)
-    melody: generateMelodyForRobot({ octaveRange, rand: melodyRand }),
+    melody: spawnMelody,
     audioAttributes,
     octaveRange,
+    audioMode: 'none',
+    rhythmicDensity: spawnMelody.length,
+    rhythmicMotifLength: 8,
+    noteVariance: 0,
     masterVolume: noiseMap
       ? getSeededVal(noiseMap, 'robot.masterVolume', spawnCount, MASTER_VOLUME_MIN, MASTER_VOLUME_MAX)
       : MASTER_VOLUME_MIN + Math.random() * (MASTER_VOLUME_MAX - MASTER_VOLUME_MIN),

--- a/src/types/Robot.ts
+++ b/src/types/Robot.ts
@@ -105,4 +105,16 @@ export interface Robot {
   linkedRobotId?: string | null;
   // Note: Visual appearance (shape, colors, scale, detail level) is derived
   // from audioAttributes and NOT stored in state - calculated at render time
+  /**
+   * Solo/mute/highlight mode set by the Robot Audio editor.
+   * AudioEngine applies solo/mute on next scheduled note. 'highlight' is visual-only.
+   * Default: 'none'
+   */
+  audioMode?: 'none' | 'solo' | 'mute' | 'highlight';
+  /** Number of melody events (4–12). Maps to `events` in generateMelodyForRobot(). */
+  rhythmicDensity?: number;
+  /** Motif length in 16th-note subdivisions (1–16). */
+  rhythmicMotifLength?: number;
+  /** When >0, constrains unique notes used during melody generation (0 = no constraint). */
+  noteVariance?: number;
 }


### PR DESCRIPTION
Add audioMode, rhythmicDensity, rhythmicMotifLength, and noteVariance to Robot.ts with short docs to keep state serialisable and self-describing.
Seed sensible defaults in spawnSystem.ts:
audioMode: 'none', rhythmicDensity derived from the initial generated melody, rhythmicMotifLength: 8, and noteVariance: 0. Add RobotAudioTab UI and CSS, integrate it into the editor, and tidy RobotMetaTab.tsx to remove unsafe any casts and use typed helpers. Keeps audio logic out of UI; defers noteVariance melody behavior implementation to a follow-up to minimize scope.
Closes #285

