### PR TITLE
test(engine): add registerRobotMelody tests and helpers

### DIFF
--- a/src/engine/AudioEngine.test.ts
+++ b/src/engine/AudioEngine.test.ts
@@ -378,6 +378,32 @@ describe('AudioEngine - Melody Lifecycle', () => {
       // Verified by code inspection: stepRegistry.delete(step) when filtered.length === 0
     });
   });
+
+  describe('Integration: registered melody -> scheduling', () => {
+    it('schedules notes from newly-registered melody on processMelodyStep', async () => {
+      const { AudioEngine } = await import('./AudioEngine');
+
+      const melody = [
+        { id: 'm1', startStep: 7, length: '8n' as const, noteIndex: 0, octave: 4 },
+      ];
+
+      const spy = vi.spyOn(AudioEngine, 'scheduleNote').mockImplementation((_params: unknown) => {});
+
+      AudioEngine.registerRobotMelody('int-1', melody);
+
+      // Simulate a transport tick for step 7 at time 0
+      AudioEngine.processMelodyStep(7, 0);
+
+      expect(spy).toHaveBeenCalled();
+
+      const calledWith = spy.mock.calls[0][0];
+      expect(calledWith.robotId).toBe('int-1');
+      expect(typeof calledWith.note).toBe('string');
+      expect(calledWith.note.endsWith('4')).toBe(true);
+
+      spy.mockRestore();
+    });
+  });
 });
 
 // Additional focused unit tests for reservation & isolation

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -1409,6 +1409,21 @@ export const AudioEngine = {
 
 
 
+  /**
+   * Register or replace a robot's melody used by the engine's playback scheduler.
+   *
+   * Behavior:
+   * - Replaces any previously-registered events for `robotId` in the internal
+   *   `stepRegistry` so subsequent scheduler ticks will use the new melody.
+   * - This method is safe to call from the main thread; it mutates module-scoped
+   *   registry data but does not touch the Tone.Transport scheduling directly.
+   * - The scheduler reads `stepRegistry` on the transport tick; callers should
+   *   expect the new melody to take effect on the next scheduled tick after
+   *   registration.
+   *
+   * @param robotId - Unique robot identifier
+   * @param melody - Array of `RobotMelodyEvent` describing start steps and notes
+   */
   registerRobotMelody(robotId: string, melody: RobotMelodyEvent[]): void {
     // Purge any existing entries for this robot before adding new ones so this
     // method is idempotent regardless of call site — prevents duplicate triggers.
@@ -1456,6 +1471,42 @@ export const AudioEngine = {
         `[AudioEngine] Unregistered melody for robot ${robotId} (${removedCount} events removed)`
       );
     }
+  },
+
+  /**
+   * Test helper: return the currently registered melody events for a robot.
+   * This exposes a read-only snapshot of the internal `stepRegistry` for tests.
+   */
+  getRegisteredMelody(robotId: string): RobotMelodyEvent[] {
+    const out: RobotMelodyEvent[] = [];
+    stepRegistry.forEach((entries) => {
+      entries.forEach((e) => {
+        if (e.robotId === robotId) out.push(e.event);
+      });
+    });
+    return out;
+  },
+
+  /**
+   * Test helper: process a single melody step as the transport tick would.
+   * Invokes `AudioEngine.scheduleNote` for all registered events whose
+   * `startStep` equals `currentStep`.
+   *
+   * @param currentStep - 1..16 step to process
+   * @param time - absolute AudioContext time passed through from transport
+   */
+  processMelodyStep(currentStep: number, time: number): void {
+    const events = stepRegistry.get(currentStep) || [];
+    const notes = getAvailableNotes();
+
+    events.forEach(({ robotId, event }) => {
+      const noteName = notes[event.noteIndex];
+      if (!noteName) return;
+      const octave = event.octave ?? 4;
+      const note = `${noteName}${octave}`;
+
+      AudioEngine.scheduleNote({ robotId, note, duration: event.length, time: time + MIN_LEAD });
+    });
   },
 
 


### PR DESCRIPTION
Add AudioEngine.getRegisteredMelody(robotId) test accessor to inspect the internal stepRegistry from tests.
Add AudioEngine.processMelodyStep(currentStep, time) test helper that simulates the transport tick scheduling behavior so tests can assert playback scheduling without needing a real Transport. Add integration/unit tests consolidated into AudioEngine.test.ts verifying register/replace/unregister behavior and that newly-registered melodies are used by the scheduler (via processMelodyStep + spy). Add docstring to registerRobotMelody describing expected behavior and thread-safety (safe to call from main thread; effects seen on next tick). Remove duplicate, now-merged test files under __tests__. Small typing/lint fixes in tests: use unknown for mocked params. Closes #286

