### PR TITLE
feat(components): add RobotAudioTab UI and tests

### DIFF
--- a/src/components/panels/screen/console/RobotAudioTab.css
+++ b/src/components/panels/screen/console/RobotAudioTab.css
@@ -1,0 +1,59 @@
+.robot-audio-tab {
+  padding: 12px;
+}
+
+.robot-audio-tab .row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.robot-audio-tab .label {
+  width: 160px;
+  font-size: 14px;
+}
+
+.robot-audio-tab .control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+}
+
+.robot-audio-tab .range {
+  flex: 1;
+  height: 32px;
+}
+
+.robot-audio-tab .value {
+  min-width: 36px;
+  text-align: center;
+}
+
+.robot-audio-tab .small-number {
+  width: 56px;
+  height: 44px;
+  /* ensure 44x44 touch target */
+}
+
+.robot-audio-tab .radio-group .radio-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-radius: 6px;
+}
+
+.robot-audio-tab .radio-btn input {
+  width: 20px;
+  height: 20px;
+}
+
+.robot-audio-tab .radio-btn.active {
+  background: var(--color-accent, #222);
+  color: var(--color-on-accent, #fff);
+}
+
+.robot-audio-tab .octave-range .sep {
+  padding: 0 8px;
+}

--- a/src/components/panels/screen/console/RobotAudioTab.test.tsx
+++ b/src/components/panels/screen/console/RobotAudioTab.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import RobotAudioTab from './RobotAudioTab';
+import { useLocaleStore } from '@/stores/localeStore';
+import { useUIStore } from '@/stores/uiStore';
+import { getActiveLocaleId } from '@/utils/localeHelpers';
+import * as melodyGen from '@/engine/melodyGenerator';
+import { AudioEngine } from '@/engine/AudioEngine';
+import type { Robot } from '@/types/Robot';
+import type { RobotMelodyEvent } from '@/engine/melodyGenerator';
+import type { Locale } from '@/types/locale';
+
+// Minimal robot fixture matching the `Robot` shape used by the component
+const makeRobot = (id = 'r1') => ({
+  id,
+  name: 'Test Robot',
+  state: 'idle',
+  position: { x: 0, y: 0 },
+  destination: null,
+  direction: 'right',
+  melody: [],
+  audioAttributes: {
+    synthType: 'PolySynth',
+    adsr: { attack: 0.01, decay: 0.1, sustain: 0.8, release: 0.3 },
+    pitchRange: { min: 100, max: 1000 },
+    filterFreq: 0,
+    waveform: 'sine',
+  },
+  octaveRange: [3, 4],
+  createdAt: Date.now(),
+  masterVolume: 0.7,
+  rhythmicDensity: 6,
+  rhythmicMotifLength: 8,
+});
+
+describe('RobotAudioTab', () => {
+  const localeId = getActiveLocaleId();
+
+  beforeEach(() => {
+    // Reset store to a known state
+    const state = useLocaleStore.getState();
+    // Ensure locale exists and is clean
+    state.setLocaleData(localeId, { robots: [] } as unknown as Partial<Locale>);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // Clear robots
+    useLocaleStore.getState().setLocaleData(localeId, { robots: [] } as unknown as Partial<Locale>);
+  });
+
+  it('updates the store when density changes and triggers regeneration', async () => {
+    const robot = makeRobot('robot-density');
+    useLocaleStore.getState().addRobot(localeId, robot as unknown as Robot);
+    // mark as selected so component's commitUpdate runs
+    useUIStore.getState().selectRobot(robot.id);
+
+    const updateSpy = vi.spyOn(useLocaleStore.getState(), 'updateRobot');
+
+    const sampleMelody = [{ id: 'm1', startStep: 1, length: '8n', noteIndex: 0, octave: 3 }];
+    const genSpy = vi.spyOn(melodyGen, 'generateMelodyForRobot').mockReturnValue(sampleMelody as unknown as RobotMelodyEvent[]);
+    const regSpy = vi.spyOn(AudioEngine, 'registerRobotMelody').mockImplementation(() => { });
+    vi.spyOn(AudioEngine, 'unregisterRobotMelody').mockImplementation(() => { });
+
+    render(<RobotAudioTab robot={robot as unknown as Robot} />);
+
+    const densityInput = screen.getByLabelText('Rhythmic density') as HTMLInputElement;
+    expect(densityInput).toBeTruthy();
+
+    // Change density to a new value
+    fireEvent.change(densityInput, { target: { value: '9' } });
+
+    expect(updateSpy).toHaveBeenCalledWith(localeId, robot.id, { rhythmicDensity: 9 });
+
+    // Allow microtasks queued via queueMicrotask to run
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(genSpy).toHaveBeenCalled();
+    expect(regSpy).toHaveBeenCalledWith(robot.id, sampleMelody as unknown as RobotMelodyEvent[]);
+  });
+
+  it('updates the store when motif length changes and triggers regeneration', async () => {
+    const robot = makeRobot('robot-motif');
+    useLocaleStore.getState().addRobot(localeId, robot as unknown as Robot);
+    // mark as selected so component's commitUpdate runs
+    useUIStore.getState().selectRobot(robot.id);
+
+    const updateSpy = vi.spyOn(useLocaleStore.getState(), 'updateRobot');
+
+    const sampleMelody = [{ id: 'm2', startStep: 1, length: '8n', noteIndex: 0, octave: 3 }];
+    const genSpy = vi.spyOn(melodyGen, 'generateMelodyForRobot').mockReturnValue(sampleMelody as unknown as RobotMelodyEvent[]);
+    const regSpy = vi.spyOn(AudioEngine, 'registerRobotMelody').mockImplementation(() => { });
+    vi.spyOn(AudioEngine, 'unregisterRobotMelody').mockImplementation(() => { });
+
+    render(<RobotAudioTab robot={robot as unknown as Robot} />);
+
+    const motifInput = screen.getByLabelText('Motif length') as HTMLInputElement;
+    expect(motifInput).toBeTruthy();
+
+    fireEvent.change(motifInput, { target: { value: '12' } });
+
+    expect(updateSpy).toHaveBeenCalledWith(localeId, robot.id, { rhythmicMotifLength: 12 });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(genSpy).toHaveBeenCalled();
+    expect(regSpy).toHaveBeenCalledWith(robot.id, sampleMelody as unknown as RobotMelodyEvent[]);
+  });
+});

--- a/src/components/panels/screen/console/RobotAudioTab.tsx
+++ b/src/components/panels/screen/console/RobotAudioTab.tsx
@@ -1,0 +1,141 @@
+import { } from 'react';
+import { getActiveLocaleId } from '@/utils/localeHelpers';
+import { useUIStore } from '@/stores/uiStore';
+import { useLocaleStore } from '@/stores/localeStore';
+import { AudioEngine } from '@/engine/AudioEngine';
+import { generateMelodyForRobot } from '@/engine/melodyGenerator';
+import type { Robot } from '@/types/Robot';
+
+import './RobotAudioTab.css';
+
+export default function RobotAudioTab({ robot }: { robot: Robot }) {
+  const localeId = getActiveLocaleId();
+  const selectedRobotId = useUIStore((s) => s.selectedRobotId);
+
+  const commitUpdate = (updates: Partial<Robot>) => {
+    if (!localeId || !selectedRobotId) return;
+    useLocaleStore.getState().updateRobot(localeId, robot.id, updates);
+  };
+
+  const scheduleRegenerate = (robotId: string) => {
+    queueMicrotask(() => {
+      try {
+        const state = useLocaleStore.getState();
+        const current = state.getRobotById(localeId, robotId);
+        if (!current) return;
+        const events = current.rhythmicDensity ?? 8;
+        const octaveRange = current.octaveRange ?? [3, 4];
+        const melody = generateMelodyForRobot({ events, octaveRange });
+        AudioEngine.unregisterRobotMelody(current.id);
+        AudioEngine.registerRobotMelody(current.id, melody as never);
+      } catch (err) {
+        console.warn('[RobotAudioTab] regenerate error', err);
+      }
+    });
+  };
+
+  // Handlers
+  const onDensityChange = (v: number) => {
+    commitUpdate({ rhythmicDensity: v });
+    scheduleRegenerate(robot.id);
+  };
+
+  const onMotifLengthChange = (v: number) => {
+    commitUpdate({ rhythmicMotifLength: v });
+    scheduleRegenerate(robot.id);
+  };
+
+  const onOctaveMinChange = (v: number) => {
+    const max = robot.octaveRange?.[1] ?? 4;
+    const min = Math.min(v, max);
+    commitUpdate({ octaveRange: [min, max] });
+  };
+
+  const onOctaveMaxChange = (v: number) => {
+    const min = robot.octaveRange?.[0] ?? 3;
+    const max = Math.max(v, min);
+    commitUpdate({ octaveRange: [min, max] });
+  };
+
+  const onAudioModeChange = (mode: string) => {
+    commitUpdate({ audioMode: mode as Robot['audioMode'] });
+  };
+
+  return (
+    <div className="robot-audio-tab">
+      <div className="row">
+        <label className="label">Density</label>
+        <div className="control">
+          <input
+            aria-label="Rhythmic density"
+            className="range"
+            type="range"
+            min={4}
+            max={12}
+            value={robot.rhythmicDensity ?? 8}
+            onChange={(e) => onDensityChange(Number(e.target.value))}
+          />
+          <div className="value">{robot.rhythmicDensity ?? 8}</div>
+        </div>
+      </div>
+
+      <div className="row">
+        <label className="label">Motif Length</label>
+        <div className="control">
+          <input
+            aria-label="Motif length"
+            className="range"
+            type="range"
+            min={1}
+            max={16}
+            value={robot.rhythmicMotifLength ?? 8}
+            onChange={(e) => onMotifLengthChange(Number(e.target.value))}
+          />
+          <div className="value">{robot.rhythmicMotifLength ?? 8}</div>
+        </div>
+      </div>
+
+      <div className="row">
+        <label className="label">Octave Range</label>
+        <div className="control octave-range">
+          <input
+            aria-label="Octave min"
+            className="small-number"
+            type="number"
+            min={1}
+            max={8}
+            value={robot.octaveRange?.[0] ?? 3}
+            onChange={(e) => onOctaveMinChange(Number(e.target.value))}
+          />
+          <span className="sep">—</span>
+          <input
+            aria-label="Octave max"
+            className="small-number"
+            type="number"
+            min={1}
+            max={8}
+            value={robot.octaveRange?.[1] ?? 4}
+            onChange={(e) => onOctaveMaxChange(Number(e.target.value))}
+          />
+        </div>
+      </div>
+
+      <div className="row control-row">
+        <label className="label">Audio Mode</label>
+        <div className="control radio-group" role="radiogroup" aria-label="Audio mode">
+          {(['none', 'solo', 'mute', 'highlight'] as const).map((m) => (
+            <label key={m} className={`radio-btn ${(robot.audioMode ?? 'none') === m ? 'active' : ''}`}>
+              <input
+                type="radio"
+                name={`audio-mode-${robot.id}`}
+                checked={(robot.audioMode ?? 'none') === m}
+                onChange={() => onAudioModeChange(m)}
+              />
+              <span className="radio-label">{m}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/panels/screen/console/RobotEditorTab.tsx
+++ b/src/components/panels/screen/console/RobotEditorTab.tsx
@@ -1,6 +1,7 @@
 import * as Tabs from '@radix-ui/react-tabs';
 
 import RobotMetaTab from './RobotMetaTab.tsx';
+import RobotAudioTab from './RobotAudioTab';
 import type { Robot } from '@/types/Robot';
 import { getActiveLocaleId } from '@/utils/localeHelpers';
 import { useUIStore } from '@/stores/uiStore';
@@ -52,7 +53,7 @@ export function RobotEditorTab() {
           </Tabs.Content>
 
           <Tabs.Content value="audio" className="tab-content">
-            {robot ? <RobotAudioPanel robot={robot} /> : <div className="empty">Robot not found</div>}
+            {robot ? <RobotAudioTab robot={robot} /> : <div className="empty">Robot not found</div>}
           </Tabs.Content>
 
           <Tabs.Content value="oscillators" className="tab-content">
@@ -66,14 +67,7 @@ export function RobotEditorTab() {
 
 // Robot meta panel is implemented in its own file: RobotMetaTab.tsx
 
-function RobotAudioPanel({ robot }: { robot: Robot }) {
-  return (
-    <div className="robot-audio-panel">
-      <p>Audio attributes are displayed here (placeholder).</p>
-      <pre className="robot-audio-pre">{JSON.stringify(robot.audioAttributes, null, 2)}</pre>
-    </div>
-  );
-}
+// Robot audio panel moved to its own file: RobotAudioTab.tsx
 
 function RobotOscillatorsPanel({ robot }: { robot: Robot }) {
   return (


### PR DESCRIPTION
Add RobotAudioTab.tsx and
RobotAudioTab.css with controls for rhythmic density, motif length, octave range, and audio mode.
Wire controls to useLocaleStore.getState().updateRobot(...) so edits update locale state live.
Schedule melody regeneration via queueMicrotask and call generateMelodyForRobot + AudioEngine.registerRobotMelody when density or motif-length change to avoid running inside Transport ticks. Replace inline placeholder in RobotEditorTab.tsx to use the new tab. Add RobotAudioTab.test.tsx asserting store updates and that density/ motif-length changes trigger melody generation and AudioEngine registration.
Refactor component to remove local setState-in-effect usage to satisfy lint rules.

Closes #287