### PR TITLE
refactor(engine): remove legacy melody path and wire tonal variance

### DIFF
--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -12,7 +12,7 @@ import type { ReverbSettings, DelaySettings, ChorusSettings, FilterSettings, EQ3
 import { getAvailableNotes, scheduleHarmonyCycle, stopHarmonyCycle } from './harmonySystem';
 import { resetBeatClock, subscribeToMeasure, initBeatClock } from './beatClock';
 import type { RobotMelodyEvent } from './melodyGenerator';
-import { applyRhythmicVariance } from './melodyGenerator';
+import { applyRhythmicVariance, applyTonalVariance } from './melodyGenerator';
 import { DEV_TUNING, WORLD_WIDTH, MIN_LEAD as CONST_MIN_LEAD } from '../constants';
 
 // MIN_LEAD: prefer project constant, fall back to 0.1s for headless/tests
@@ -547,12 +547,17 @@ function startMelodyPlayback(): void {
           const originalMelody = robot.melody;
           const originalSteps = originalMelody.map((e) => e.startStep);
 
-          // Apply variance (returns new array or original)
-          const variedMelody = applyRhythmicVariance(originalMelody as never);
+          // Apply variance (returns new array or original); both apply independently
+          const rhythmicVaried = applyRhythmicVariance(originalMelody as never);
+          const variedMelody = applyTonalVariance(rhythmicVaried as never);
 
-          // Detect if any startStep actually changed
+          // Detect if any field changed across both passes
           const newSteps = variedMelody.map((e) => e.startStep);
-          const changed = originalSteps.some((step, i) => step !== newSteps[i]);
+          const newIndices = variedMelody.map((e) => e.noteIndex);
+          const originalIndices = originalMelody.map((e) => e.noteIndex);
+          const changed =
+            originalSteps.some((step, i) => step !== newSteps[i]) ||
+            originalIndices.some((idx, i) => idx !== newIndices[i]);
 
           if (changed) {
             // Update stepRegistry with varied melody for THIS loop's playback only
@@ -561,12 +566,17 @@ function startMelodyPlayback(): void {
             AudioEngine.registerRobotMelody(robot.id, variedMelody as never);
 
             if (DEV_TUNING) {
-              const shifts = originalSteps
-                .map((step, i) => (step !== newSteps[i] ? `event${i}:${step}→${newSteps[i]}` : null))
+              const stepShifts = originalSteps
+                .map((step, i) => (step !== newSteps[i] ? `step${i}:${step}→${newSteps[i]}` : null))
                 .filter((x) => x !== null)
                 .join(', ');
+              const noteShifts = originalIndices
+                .map((idx, i) => (idx !== newIndices[i] ? `note${i}:${idx}→${newIndices[i]}` : null))
+                .filter((x) => x !== null)
+                .join(', ');
+              const summary = [stepShifts, noteShifts].filter(Boolean).join(' | ');
               console.log(
-                `[AudioEngine] Rhythmic variance applied to robot ${robot.id}: ${shifts}`
+                `[AudioEngine] Variance applied to robot ${robot.id}: ${summary}`
               );
             }
           }

--- a/src/engine/melodyGenerator.test.ts
+++ b/src/engine/melodyGenerator.test.ts
@@ -674,11 +674,11 @@ describe('buildMotifOnsets', () => {
 describe('gridUnitsToDuration', () => {
   it('1 unit → 16n', () => expect(gridUnitsToDuration(1)).toBe('16n'));
   it('0 units → 16n', () => expect(gridUnitsToDuration(0)).toBe('16n'));
-  it('2 units → 8n',  () => expect(gridUnitsToDuration(2)).toBe('8n'));
-  it('3 units → 8n',  () => expect(gridUnitsToDuration(3)).toBe('8n'));
-  it('4 units → 4n',  () => expect(gridUnitsToDuration(4)).toBe('4n'));
-  it('6 units → 4n',  () => expect(gridUnitsToDuration(6)).toBe('4n'));
-  it('7 units → 2n',  () => expect(gridUnitsToDuration(7)).toBe('2n'));
+  it('2 units → 8n', () => expect(gridUnitsToDuration(2)).toBe('8n'));
+  it('3 units → 8n', () => expect(gridUnitsToDuration(3)).toBe('8n'));
+  it('4 units → 4n', () => expect(gridUnitsToDuration(4)).toBe('4n'));
+  it('6 units → 4n', () => expect(gridUnitsToDuration(6)).toBe('4n'));
+  it('7 units → 2n', () => expect(gridUnitsToDuration(7)).toBe('2n'));
   it('16 units → 2n', () => expect(gridUnitsToDuration(16)).toBe('2n'));
 });
 
@@ -688,13 +688,13 @@ describe('gridUnitsToDuration', () => {
 
 describe('generateMelodyForRobot — GenerateMelodyForRobotOptions', () => {
   it('returns the requested number of events', () => {
-    const melody = generateMelodyForRobot({ eventCount: 4, octaveMin: 3, octaveMax: 5, seed: 1 });
+    const melody = generateMelodyForRobot({ onsetCount: 4, octaveMin: 3, octaveMax: 5, seed: 1 });
     // density defaults to eventCount when rhythmicDensity is omitted
     expect(melody.length).toBe(4);
   });
 
   it('all noteIndex values are in [0, 7]', () => {
-    const melody = generateMelodyForRobot({ eventCount: 12, octaveMin: 2, octaveMax: 6, seed: 42 });
+    const melody = generateMelodyForRobot({ onsetCount: 12, octaveMin: 2, octaveMax: 6, seed: 42 });
     melody.forEach((e) => {
       expect(e.noteIndex).toBeGreaterThanOrEqual(0);
       expect(e.noteIndex).toBeLessThanOrEqual(7);
@@ -702,7 +702,7 @@ describe('generateMelodyForRobot — GenerateMelodyForRobotOptions', () => {
   });
 
   it('all octave values are within [octaveMin, octaveMax]', () => {
-    const melody = generateMelodyForRobot({ eventCount: 8, octaveMin: 3, octaveMax: 5, seed: 7 });
+    const melody = generateMelodyForRobot({ onsetCount: 8, octaveMin: 3, octaveMax: 5, seed: 7 });
     melody.forEach((e) => {
       expect(e.octave).toBeGreaterThanOrEqual(3);
       expect(e.octave).toBeLessThanOrEqual(5);
@@ -710,12 +710,12 @@ describe('generateMelodyForRobot — GenerateMelodyForRobotOptions', () => {
   });
 
   it('octaveMin === octaveMax pins all events to that octave', () => {
-    const melody = generateMelodyForRobot({ eventCount: 6, octaveMin: 4, octaveMax: 4, seed: 99 });
+    const melody = generateMelodyForRobot({ onsetCount: 6, octaveMin: 4, octaveMax: 4, seed: 99 });
     melody.forEach((e) => expect(e.octave).toBe(4));
   });
 
   it('swapped octaveMin/octaveMax is normalised (no events out of range)', () => {
-    const melody = generateMelodyForRobot({ eventCount: 6, octaveMin: 5, octaveMax: 3, seed: 5 });
+    const melody = generateMelodyForRobot({ onsetCount: 6, octaveMin: 5, octaveMax: 3, seed: 5 });
     melody.forEach((e) => {
       expect(e.octave).toBeGreaterThanOrEqual(3);
       expect(e.octave).toBeLessThanOrEqual(5);
@@ -723,7 +723,7 @@ describe('generateMelodyForRobot — GenerateMelodyForRobotOptions', () => {
   });
 
   it('all startStep values are in [1, 16]', () => {
-    const melody = generateMelodyForRobot({ eventCount: 8, octaveMin: 3, octaveMax: 4, seed: 10 });
+    const melody = generateMelodyForRobot({ onsetCount: 8, octaveMin: 3, octaveMax: 4, seed: 10 });
     melody.forEach((e) => {
       expect(e.startStep).toBeGreaterThanOrEqual(1);
       expect(e.startStep).toBeLessThanOrEqual(16);
@@ -733,7 +733,7 @@ describe('generateMelodyForRobot — GenerateMelodyForRobotOptions', () => {
   it('eventCount=4 with seed produces roughly quarter-note spacing', () => {
     // 4 onsets across 16 subdivisions ≈ one per 4 grid units (quarter-note)
     const melody = generateMelodyForRobot({
-      eventCount: 4,
+      onsetCount: 4,
       rhythmicDensity: 4,
       octaveMin: 3,
       octaveMax: 4,
@@ -750,7 +750,7 @@ describe('generateMelodyForRobot — GenerateMelodyForRobotOptions', () => {
   it('eventCount=8 with seed produces roughly eighth-note spacing', () => {
     // 8 onsets across 16 subdivisions ≈ one per 2 grid units (eighth-note)
     const melody = generateMelodyForRobot({
-      eventCount: 8,
+      onsetCount: 8,
       rhythmicDensity: 8,
       octaveMin: 3,
       octaveMax: 4,
@@ -767,7 +767,7 @@ describe('generateMelodyForRobot — GenerateMelodyForRobotOptions', () => {
   it('short rhythmicMotifLength produces repeating onset pattern', () => {
     // motifLength=4, subdivisions=16 → repeats=4; pattern tiles every 4 steps
     const melody = generateMelodyForRobot({
-      eventCount: 4,
+      onsetCount: 4,
       rhythmicDensity: 4,
       rhythmicMotifLength: 4,
       octaveMin: 3,
@@ -785,7 +785,7 @@ describe('generateMelodyForRobot — GenerateMelodyForRobotOptions', () => {
 
   it('rhythmicMotifLength === subdivisions produces non-repeating output', () => {
     const melody = generateMelodyForRobot({
-      eventCount: 6,
+      onsetCount: 6,
       rhythmicDensity: 6,
       rhythmicMotifLength: 16,
       octaveMin: 3,
@@ -800,7 +800,7 @@ describe('generateMelodyForRobot — GenerateMelodyForRobotOptions', () => {
 
   it('noteVariance > 0 prefers new unique notes until set fills (deterministic)', () => {
     const nv = 3;
-    const melody = generateMelodyForRobot({ eventCount: 6, octaveMin: 3, octaveMax: 4, seed: 11, noteVariance: nv });
+    const melody = generateMelodyForRobot({ onsetCount: 6, octaveMin: 3, octaveMax: 4, seed: 11, noteVariance: nv });
     const seen = new Set<number>();
     for (let i = 0; i < melody.length; i++) {
       const idx = melody[i].noteIndex;
@@ -814,7 +814,7 @@ describe('generateMelodyForRobot — GenerateMelodyForRobotOptions', () => {
   });
 
   it('noteVariance === 8 draws without replacement until all 8 notes used', () => {
-    const melody = generateMelodyForRobot({ eventCount: 8, octaveMin: 3, octaveMax: 5, seed: 7, noteVariance: 8 });
+    const melody = generateMelodyForRobot({ onsetCount: 8, octaveMin: 3, octaveMax: 5, seed: 7, noteVariance: 8 });
     const indices = melody.map((e) => e.noteIndex);
     const uniq = new Set(indices);
     expect(uniq.size).toBe(8);
@@ -823,7 +823,7 @@ describe('generateMelodyForRobot — GenerateMelodyForRobotOptions', () => {
   });
 
   it('is deterministic with the same seed', () => {
-    const opts = { eventCount: 6, octaveMin: 3, octaveMax: 5, seed: 77 };
+    const opts = { onsetCount: 6, octaveMin: 3, octaveMax: 5, seed: 77 };
     const a = generateMelodyForRobot(opts);
     const b = generateMelodyForRobot(opts);
     expect(a.map((e) => e.startStep)).toEqual(b.map((e) => e.startStep));
@@ -832,13 +832,13 @@ describe('generateMelodyForRobot — GenerateMelodyForRobotOptions', () => {
   });
 
   it('each event has a valid length (16n | 8n | 4n | 2n)', () => {
-    const melody = generateMelodyForRobot({ eventCount: 8, octaveMin: 3, octaveMax: 4, seed: 6 });
+    const melody = generateMelodyForRobot({ onsetCount: 8, octaveMin: 3, octaveMax: 4, seed: 6 });
     const valid = new Set(['16n', '8n', '4n', '2n']);
     melody.forEach((e) => expect(valid.has(e.length)).toBe(true));
   });
 
   it('each event has a unique id', () => {
-    const melody = generateMelodyForRobot({ eventCount: 8, octaveMin: 3, octaveMax: 4, seed: 8 });
+    const melody = generateMelodyForRobot({ onsetCount: 8, octaveMin: 3, octaveMax: 4, seed: 8 });
     const ids = melody.map((e) => e.id);
     expect(new Set(ids).size).toBe(ids.length);
   });

--- a/src/engine/melodyGenerator.ts
+++ b/src/engine/melodyGenerator.ts
@@ -15,23 +15,17 @@ export interface RobotMelodyEvent {
   octave: number;   // Concrete octave assigned at spawn time
 }
 
-export interface MelodyGeneratorOptions {
-  events?: number; // Number of notes (default: 4-12)
-  rand?: () => number; // RNG for testing (default: Math.random)
-  syncopationBias?: number; // 0-1, off-beat preference (default: 0.4)
-  octaveRange?: [number, number]; // [min, max] octave band for this robot
-  /** When >0, constrains unique notes used during melody generation (0 = no constraint). */
-  noteVariance?: number;
-}
-
 /**
- * New-style options for generateMelodyForRobot.
- * Uses explicit octaveMin/octaveMax instead of a tuple, and adds rhythm
- * parameters that will drive the motif algorithm (Step 2).
+ * Options for generateMelodyForRobot.
+ * Uses explicit octaveMin/octaveMax and controls the motif-repetition density algorithm.
  */
 export interface GenerateMelodyForRobotOptions {
-  /** Number of note events to generate (4–12). */
-  eventCount: number;
+  /**
+   * Target number of note onsets per measure (4–12). Used as the density hint
+   * for buildMotifOnsets; the actual event count may differ slightly due to
+   * motif tiling and truncation.
+   */
+  onsetCount: number;
   /** Minimum octave (inclusive). */
   octaveMin: number;
   /** Maximum octave (inclusive). Must be >= octaveMin. */
@@ -52,14 +46,15 @@ export interface GenerateMelodyForRobotOptions {
    */
   subdivisions?: number;
   /**
-   * Measure length in beats (default: 4 for 4/4).
-   */
-  measureBeats?: number;
-  /**
    * Integer seed for deterministic RNG. When provided, a seeded PRNG is used
    * instead of Math.random — useful for reproducible tests.
    */
   seed?: number;
+  /**
+   * RNG function override. When provided, used instead of `seed` or `Math.random`.
+   * Useful when callers supply a deterministic noise-map-based PRNG.
+   */
+  rand?: () => number;
   /** When >0, constrains unique notes used during melody generation (0 = no constraint). Valid range: 0..8 */
   noteVariance?: number;
 }
@@ -69,18 +64,10 @@ export interface GenerateMelodyForRobotOptions {
 // ========================================
 const MIN_EVENTS = 4;
 const MAX_EVENTS = 12;
-const DEFAULT_SYNCOPATION_BIAS = 0.4;
 /** Probability that a successive note jumps more than one octave (when range allows). */
 const OCTAVE_JUMP_CHANCE = 0.15;
-const DEFAULT_OCTAVE_RANGE: [number, number] = [3, 4];
 
 const NOTE_INDEX_WEIGHTS = [0.35, 0.2, 0.15, 0.1, 0.07, 0.06, 0.04, 0.03];
-const LENGTH_WEIGHTS = [0.5, 0.25, 0.15, 0.1];
-// Order must align with LENGTH_WEIGHTS: 8n=50%, 4n=25%, 2n=15%, 16n=10%
-const LENGTHS: NoteDuration[] = ['8n', '4n', '2n', '16n'];
-
-const ON_BEAT_STEPS = [1, 3, 5, 7, 9, 11, 13, 15];
-const OFF_BEAT_STEPS = [2, 4, 6, 8, 10, 12, 14, 16];
 
 /** Default rhythmic density (onsets per measure). */
 export const DEFAULT_RHYTHMIC_DENSITY = 8;
@@ -88,8 +75,6 @@ export const DEFAULT_RHYTHMIC_DENSITY = 8;
 export const DEFAULT_RHYTHMIC_MOTIF_LENGTH = 8;
 /** Default subdivision grid per measure (16 sixteenth notes in 4/4). */
 export const DEFAULT_SUBDIVISIONS = 16;
-/** Default measure length in beats (4/4). */
-export const DEFAULT_MEASURE_BEATS = 4;
 
 /** Probability of applying rhythmic variance per 16-step loop (recommended: 0.2) */
 const DEFAULT_VARIANCE_PROBABILITY = 0.20;
@@ -316,192 +301,86 @@ export function gridUnitsToDuration(units: number): NoteDuration {
 }
 
 // ========================================
-// OVERLOADS
+// MELODY GENERATION
 // ========================================
 
-export function generateMelodyForRobot(opts: GenerateMelodyForRobotOptions): RobotMelodyEvent[];
-export function generateMelodyForRobot(opts?: MelodyGeneratorOptions): RobotMelodyEvent[];
-
 /**
- * Generates a melody for a robot.
- *
- * When called with GenerateMelodyForRobotOptions (has `octaveMin`), uses the
- * motif-repetition density algorithm — onset positions are built by
- * buildMotifOnsets() and durations are computed as the gap to the next onset.
- *
- * When called with the legacy MelodyGeneratorOptions (or no args), falls back
- * to the original syncopation-biased step-picker so all existing callers are
- * unaffected.
+ * Generates a melody for a robot using the motif-repetition density algorithm.
+ * Onset positions are built by buildMotifOnsets() and durations are computed
+ * as the gap to the next onset.
  */
 export function generateMelodyForRobot(
-  opts?: MelodyGeneratorOptions | GenerateMelodyForRobotOptions
+  opts: GenerateMelodyForRobotOptions
 ): RobotMelodyEvent[] {
-  // ── New-style path: motif & density algorithm ──────────────────────────
-  if (opts !== undefined && 'octaveMin' in opts) {
-    const o = opts as GenerateMelodyForRobotOptions;
-    const rand = o.seed !== undefined ? alea(String(o.seed)) : Math.random;
-    const subdivisions = o.subdivisions ?? DEFAULT_SUBDIVISIONS;
-    const density = Math.max(
-      MIN_EVENTS,
-      Math.min(MAX_EVENTS, o.rhythmicDensity ?? o.eventCount),
-    );
-    const motifLength = o.rhythmicMotifLength ?? DEFAULT_RHYTHMIC_MOTIF_LENGTH;
-    const octMin = Math.min(o.octaveMin, o.octaveMax);
-    const octMax = Math.max(o.octaveMin, o.octaveMax);
+  const rand = opts.rand ?? (opts.seed !== undefined ? alea(String(opts.seed)) : Math.random);
+  const subdivisions = opts.subdivisions ?? DEFAULT_SUBDIVISIONS;
+  const density = Math.max(
+    MIN_EVENTS,
+    Math.min(MAX_EVENTS, opts.rhythmicDensity ?? opts.onsetCount),
+  );
+  const motifLength = opts.rhythmicMotifLength ?? DEFAULT_RHYTHMIC_MOTIF_LENGTH;
+  const octMin = Math.min(opts.octaveMin, opts.octaveMax);
+  const octMax = Math.max(opts.octaveMin, opts.octaveMax);
 
-    // Build onset grid positions (0-indexed, 0..subdivisions-1)
-    const onsets = buildMotifOnsets(density, motifLength, subdivisions, rand);
+  // Build onset grid positions (0-indexed, 0..subdivisions-1)
+  const onsets = buildMotifOnsets(density, motifLength, subdivisions, rand);
 
-    let currentOctave = octMin + Math.floor(rand() * (octMax - octMin + 1));
-    const melody: RobotMelodyEvent[] = [];
-
-    // Note-variance state
-    const noteVariance = Math.max(0, Math.min(8, Math.trunc(o.noteVariance ?? 0)));
-    const uniqueSet = new Set<number>();
-    let withoutReplacementPool: number[] | null = null;
-    if (noteVariance === 8) {
-      const pool = Array.from({ length: 8 }, (_, i) => i);
-      withoutReplacementPool = [];
-      while (pool.length > 0) {
-        const j = Math.floor(rand() * pool.length);
-        withoutReplacementPool.push(pool.splice(j, 1)[0]);
-      }
-    }
-
-    for (let i = 0; i < onsets.length; i++) {
-      // 15% chance to jump to a non-adjacent octave when range allows
-      if (i > 0 && rand() < OCTAVE_JUMP_CHANCE) {
-        const jumpCandidates: number[] = [];
-        for (let oct = octMin; oct <= octMax; oct++) {
-          if (Math.abs(oct - currentOctave) > 1) jumpCandidates.push(oct);
-        }
-        if (jumpCandidates.length > 0) {
-          currentOctave = jumpCandidates[Math.floor(rand() * jumpCandidates.length)];
-        }
-      }
-
-      // Duration = gap to next onset; last onset fills to measure end
-      const nextOnset = i < onsets.length - 1 ? onsets[i + 1] : subdivisions;
-      const durationUnits = nextOnset - onsets[i];
-
-      // Pick noteIndex honoring noteVariance
-      let noteIndex: number;
-      if (noteVariance === 0) {
-        noteIndex = pickWeightedIndex(rand);
-      } else if (noteVariance === 8) {
-        if (!withoutReplacementPool || withoutReplacementPool.length === 0) {
-          const pool = Array.from({ length: 8 }, (_, i) => i);
-          withoutReplacementPool = [];
-          while (pool.length > 0) {
-            const j = Math.floor(rand() * pool.length);
-            withoutReplacementPool.push(pool.splice(j, 1)[0]);
-          }
-        }
-        noteIndex = withoutReplacementPool.shift()!;
-        uniqueSet.add(noteIndex);
-      } else {
-        if (uniqueSet.size < noteVariance) {
-          // prefer selecting notes not yet in the set (uniform among remaining)
-          const remaining = Array.from({ length: 8 }, (_, i) => i).filter((i) => !uniqueSet.has(i));
-          noteIndex = remaining[Math.floor(rand() * remaining.length)];
-          uniqueSet.add(noteIndex);
-        } else {
-          // choose among established set — weighted by NOTE_INDEX_WEIGHTS restricted to set
-          const setArray = Array.from(uniqueSet);
-          const totalW = setArray.reduce((s, idx) => s + NOTE_INDEX_WEIGHTS[idx], 0);
-          let r = rand() * totalW;
-          noteIndex = setArray[setArray.length - 1];
-          for (const idx of setArray) {
-            r -= NOTE_INDEX_WEIGHTS[idx];
-            if (r <= 0) { noteIndex = idx; break; }
-          }
-        }
-      }
-
-      melody.push({
-        id: crypto.randomUUID(),
-        startStep: onsets[i] + 1, // 1-indexed to match existing RobotMelodyEvent convention
-        length: gridUnitsToDuration(durationUnits),
-        noteIndex,
-        octave: currentOctave,
-      });
-    }
-
-    return melody;
-  }
-
-  // ── Legacy path: syncopation-biased step-picker (unchanged) ────────────
-  const legacyOpts = (opts as MelodyGeneratorOptions) ?? {};
-  const rand = legacyOpts.rand ?? Math.random;
-  const legacyNoteVariance = Math.max(0, Math.min(8, Math.trunc(legacyOpts.noteVariance ?? 0)));
-  const eventsCount =
-    legacyOpts.events ?? MIN_EVENTS + Math.floor(rand() * (MAX_EVENTS - MIN_EVENTS + 1));
-  const syncopationBias = legacyOpts.syncopationBias ?? DEFAULT_SYNCOPATION_BIAS;
-
-  const [octMin, octMax] = legacyOpts.octaveRange ?? DEFAULT_OCTAVE_RANGE;
   let currentOctave = octMin + Math.floor(rand() * (octMax - octMin + 1));
-
   const melody: RobotMelodyEvent[] = [];
-  const usedSlots = new Set<number>();
-  const legacyUniqueSet = new Set<number>();
-  let legacyPool: number[] | null = null;
-  if (legacyNoteVariance === 8) {
+
+  // Note-variance state
+  const noteVariance = Math.max(0, Math.min(8, Math.trunc(opts.noteVariance ?? 0)));
+  const uniqueSet = new Set<number>();
+  let withoutReplacementPool: number[] | null = null;
+  if (noteVariance === 8) {
     const pool = Array.from({ length: 8 }, (_, i) => i);
-    legacyPool = [];
+    withoutReplacementPool = [];
     while (pool.length > 0) {
       const j = Math.floor(rand() * pool.length);
-      legacyPool.push(pool.splice(j, 1)[0]);
+      withoutReplacementPool.push(pool.splice(j, 1)[0]);
     }
   }
 
-  for (let i = 0; i < eventsCount; i++) {
-    // 15% chance to jump to a non-adjacent octave (requires span of at least 2)
+  for (let i = 0; i < onsets.length; i++) {
+    // 15% chance to jump to a non-adjacent octave when range allows
     if (i > 0 && rand() < OCTAVE_JUMP_CHANCE) {
       const jumpCandidates: number[] = [];
-      for (let o = octMin; o <= octMax; o++) {
-        if (Math.abs(o - currentOctave) > 1) jumpCandidates.push(o);
+      for (let oct = octMin; oct <= octMax; oct++) {
+        if (Math.abs(oct - currentOctave) > 1) jumpCandidates.push(oct);
       }
       if (jumpCandidates.length > 0) {
         currentOctave = jumpCandidates[Math.floor(rand() * jumpCandidates.length)];
       }
     }
 
-    // Pick step position (with syncopation bias)
-    const useOffBeat = rand() < syncopationBias;
-    const candidateSteps = useOffBeat ? OFF_BEAT_STEPS : ON_BEAT_STEPS;
+    // Duration = gap to next onset; last onset fills to measure end
+    const nextOnset = i < onsets.length - 1 ? onsets[i + 1] : subdivisions;
+    const durationUnits = nextOnset - onsets[i];
 
-    let startStep = candidateSteps[Math.floor(rand() * candidateSteps.length)];
-
-    // Avoid duplicate slots (with retry limit)
-    let attempts = 0;
-    while (usedSlots.has(startStep) && attempts < 8) {
-      startStep = candidateSteps[Math.floor(rand() * candidateSteps.length)];
-      attempts++;
-    }
-    usedSlots.add(startStep);
-
-    // select noteIndex honoring legacyNoteVariance
+    // Pick noteIndex honoring noteVariance
     let noteIndex: number;
-    if (legacyNoteVariance === 0) {
+    if (noteVariance === 0) {
       noteIndex = pickWeightedIndex(rand);
-    } else if (legacyNoteVariance === 8) {
-      if (!legacyPool || legacyPool.length === 0) {
+    } else if (noteVariance === 8) {
+      if (!withoutReplacementPool || withoutReplacementPool.length === 0) {
         const pool = Array.from({ length: 8 }, (_, i) => i);
-        legacyPool = [];
+        withoutReplacementPool = [];
         while (pool.length > 0) {
           const j = Math.floor(rand() * pool.length);
-          legacyPool.push(pool.splice(j, 1)[0]);
+          withoutReplacementPool.push(pool.splice(j, 1)[0]);
         }
       }
-      noteIndex = legacyPool.shift()!;
-      legacyUniqueSet.add(noteIndex);
+      noteIndex = withoutReplacementPool.shift()!;
+      uniqueSet.add(noteIndex);
     } else {
-      if (legacyUniqueSet.size < legacyNoteVariance) {
-        const remaining = Array.from({ length: 8 }, (_, i) => i).filter((i) => !legacyUniqueSet.has(i));
+      if (uniqueSet.size < noteVariance) {
+        // prefer selecting notes not yet in the set (uniform among remaining)
+        const remaining = Array.from({ length: 8 }, (_, i) => i).filter((i) => !uniqueSet.has(i));
         noteIndex = remaining[Math.floor(rand() * remaining.length)];
-        legacyUniqueSet.add(noteIndex);
+        uniqueSet.add(noteIndex);
       } else {
-        const setArray = Array.from(legacyUniqueSet);
+        // choose among established set — weighted by NOTE_INDEX_WEIGHTS restricted to set
+        const setArray = Array.from(uniqueSet);
         const totalW = setArray.reduce((s, idx) => s + NOTE_INDEX_WEIGHTS[idx], 0);
         let r = rand() * totalW;
         noteIndex = setArray[setArray.length - 1];
@@ -514,8 +393,8 @@ export function generateMelodyForRobot(
 
     melody.push({
       id: crypto.randomUUID(),
-      startStep,
-      length: pickLength(rand),
+      startStep: onsets[i] + 1, // 1-indexed to match existing RobotMelodyEvent convention
+      length: gridUnitsToDuration(durationUnits),
       noteIndex,
       octave: currentOctave,
     });
@@ -538,20 +417,4 @@ export function pickWeightedIndex(rand: () => number = Math.random): number {
   }
 
   return NOTE_INDEX_WEIGHTS.length - 1;
-}
-
-/**
- * Picks a note length with bias toward shorter durations.
- * '16n' 10%, '8n' 50%, '4n' 25%, '2n' 15%
- */
-export function pickLength(rand: () => number = Math.random): NoteDuration {
-  const r = rand();
-  let acc = 0;
-
-  for (let i = 0; i < LENGTH_WEIGHTS.length; i++) {
-    acc += LENGTH_WEIGHTS[i];
-    if (r <= acc) return LENGTHS[i];
-  }
-
-  return '8n';
 }

--- a/src/engine/regenerateMelody.ts
+++ b/src/engine/regenerateMelody.ts
@@ -29,7 +29,7 @@ export function regenerateMelody(robot: Robot, localeId: string): void {
   const [octMin, octMax] = robot.octaveRange;
 
   const newMelody = generateMelodyForRobot({
-    eventCount: robot.rhythmicDensity ?? 6,
+    onsetCount: robot.rhythmicDensity ?? 6,
     octaveMin: octMin,
     octaveMax: octMax,
     rhythmicDensity: robot.rhythmicDensity ?? 6,

--- a/src/systems/factorySystem.test.ts
+++ b/src/systems/factorySystem.test.ts
@@ -42,6 +42,7 @@ vi.mock('../engine/beatClock', () => ({
 
 vi.mock('../engine/melodyGenerator', () => ({
   generateMelodyForRobot: vi.fn(() => []),
+  DEFAULT_RHYTHMIC_DENSITY: 8,
 }));
 
 vi.mock('./spawnSystem', () => ({

--- a/src/systems/factorySystem.ts
+++ b/src/systems/factorySystem.ts
@@ -9,7 +9,7 @@ import { usePlanetStore } from '../stores/planetStore';
 import type { LocaleSettings } from '../types/locale';
 import { AudioEngine } from '../engine/AudioEngine';
 import { scheduleRepeat, cancelSchedule } from '../engine/beatClock';
-import { generateMelodyForRobot } from '../engine/melodyGenerator';
+import { generateMelodyForRobot, DEFAULT_RHYTHMIC_DENSITY } from '../engine/melodyGenerator';
 import { generateAudioAttributes } from './spawnSystem';
 import { getLocaleNoiseMap } from '../utils/noiseMaps';
 import { DEV_TUNING } from '../constants';
@@ -156,7 +156,7 @@ export function createRobotFromFactory(factory: Actor, localeId?: string): Robot
     position: { ...factory.position },
     destination: null,
     direction: 'right',
-    melody: generateMelodyForRobot(),
+    melody: generateMelodyForRobot({ octaveMin: 3, octaveMax: 5, onsetCount: DEFAULT_RHYTHMIC_DENSITY }),
     audioAttributes: noiseMap ? generateAudioAttributes(noiseMap, offset) : generateAudioAttributes(
       // Inline trivial fallback noise map (uniform midpoint) when locale is unavailable
       (() => { const fn = (_x: number, _y: number) => 0 as number; return fn; })() as Parameters<typeof generateAudioAttributes>[0],

--- a/src/systems/spawnSystem.ts
+++ b/src/systems/spawnSystem.ts
@@ -5,7 +5,7 @@ import type { NoiseFunction2D } from 'simplex-noise';
 import type { Vec2 } from '../types/Vec2';
 import type { Robot, AudioAttributes, SynthType, WaveformType } from '../types/Robot';
 import { RobotState } from '../types/Robot';
-import { generateMelodyForRobot } from '../engine/melodyGenerator';
+import { generateMelodyForRobot, DEFAULT_RHYTHMIC_DENSITY } from '../engine/melodyGenerator';
 import { AudioEngine } from '../engine/AudioEngine';
 import type { LayeredWave, LayerDescriptor } from '../types/layeredAudio';
 import { scheduleRepeat, cancelSchedule } from '../engine/beatClock';
@@ -366,7 +366,7 @@ export function spawnRobot(localeId: string): void {
     ? () => getSeededVal(noiseMap, 'melody.rand', spawnCount * 100 + melodyCallIndex++)
     : Math.random;
 
-  const spawnMelody = generateMelodyForRobot({ octaveRange, rand: melodyRand });
+  const spawnMelody = generateMelodyForRobot({ octaveMin: octaveRange[0], octaveMax: octaveRange[1], onsetCount: DEFAULT_RHYTHMIC_DENSITY, rand: melodyRand });
 
   const robot: Robot = {
     id: crypto.randomUUID(),


### PR DESCRIPTION
refactor(engine): remove legacy melody path and wire tonal variance

- Remove `MelodyGeneratorOptions` (syncopation-biased legacy path) and
  all associated constants: `DEFAULT_SYNCOPATION_BIAS`, `ON_BEAT_STEPS`,
  `OFF_BEAT_STEPS`, `LENGTH_WEIGHTS`, `LENGTHS`, `DEFAULT_OCTAVE_RANGE`
- Remove `pickLength()` export (was only used by the legacy path)
- Remove `measureBeats` field and `DEFAULT_MEASURE_BEATS` constant (never
  read by the implementation)
- Rename `GenerateMelodyForRobotOptions.eventCount` to `onsetCount` to
  accurately reflect that it is a density hint, not a guaranteed count
- Add `rand?` to `GenerateMelodyForRobotOptions` so noise-map-based RNG
  can be passed directly without seed conversion
- Wire `applyTonalVariance` into the AudioEngine loop boundary handler;
  runs independently of `applyRhythmicVariance` each loop (~20% chance)
- Migrate `spawnSystem` and `factorySystem` to `GenerateMelodyForRobotOptions`
- Fix `factorySystem.test.ts` mock to expose `DEFAULT_RHYTHMIC_DENSITY`