### PR TITLE
 feat(engine): add reReserveVoice and test fixes

### DIFF
--- a/src/engine/AudioEngine.test.ts
+++ b/src/engine/AudioEngine.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { useLocaleStore } from '../stores/localeStore';
-import { DEFAULT_LOCALE_ID } from '../stores/planetStore';
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../utils/localeHelpers', () => ({ getActiveLocaleId: vi.fn(() => 'testLocale') }));
 
 // Mock Tone.js to avoid audio context initialization in tests
 vi.mock('tone', () => ({
@@ -144,6 +148,64 @@ vi.mock('../constants', () => ({
 }));
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { AudioEngine } from './AudioEngine';
+import { useLocaleStore } from '../stores/localeStore';
+import { DEFAULT_LOCALE_ID } from '../stores/planetStore';
+
+describe('AudioEngine.reReserveVoice', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('releases and re-reserves using updated audioAttributes', () => {
+    vi.spyOn(useLocaleStore, 'getState').mockReturnValue({
+      locales: {
+        testLocale: {
+          robots: [
+            {
+              id: 'r1',
+              name: '',
+              state: 'idle',
+              direction: 'right',
+              position: { x: 960, y: 0 },
+              destination: null,
+              createdAt: Date.now(),
+              melody: [],
+              octaveRange: [3, 4],
+              masterVolume: 0.8,
+              audioMode: 'none',
+              audioAttributes: {
+                waveform: 'sine',
+                adsr: { attack: 0.01, decay: 0.1, sustain: 0.8, release: 0.5 },
+                filterFreq: 1200,
+                visualAudioMap: { layeredWave: { base: 'sine', layers: [{ type: 'sine' }] } },
+                phase: 37,
+                detune: 5,
+                pulseWidth: 0.42,
+              },
+            },
+          ],
+        },
+      },
+    } as any);
+
+    const reserveSpy = vi.spyOn(AudioEngine, 'reserveVoice').mockImplementation(() => true);
+    const releaseSpy = vi.spyOn(AudioEngine, 'releaseVoice').mockImplementation(() => { });
+
+    const res = AudioEngine.reReserveVoice('r1');
+
+    expect(res).toBe(true);
+    expect(releaseSpy).toHaveBeenCalledWith('r1');
+    expect(reserveSpy).toHaveBeenCalledWith(
+      'r1',
+      expect.objectContaining({ base: 'sine' }),
+      37,
+      5,
+      0.42,
+    );
+  });
+});
 
 // The following audioMode tests were merged from AudioEngine.audioMode.test.ts
 // They require importing the locale store after a module reset to ensure
@@ -293,6 +355,8 @@ describe('AudioEngine - audioMode enforcement (solo/mute/highlight)', () => {
   it('mutes robots with audioMode=\'mute\' (no synth calls)', async () => {
     const Tone = await import('tone');
     const { AudioEngine } = await import('./AudioEngine');
+    const helpers = await import('../utils/localeHelpers');
+    (helpers.getActiveLocaleId as ReturnType<typeof vi.fn>).mockReturnValue(merged_DEFAULT_LOCALE_ID);
 
     // Populate locale robots: one muted, one normal
     merged_useLocaleStore.getState().setLocaleData(merged_DEFAULT_LOCALE_ID, {
@@ -339,6 +403,8 @@ describe('AudioEngine - audioMode enforcement (solo/mute/highlight)', () => {
   it('enforces solo: only solo robot produces audio', async () => {
     const Tone = await import('tone');
     const { AudioEngine } = await import('./AudioEngine');
+    const helpers = await import('../utils/localeHelpers');
+    (helpers.getActiveLocaleId as ReturnType<typeof vi.fn>).mockReturnValue(merged_DEFAULT_LOCALE_ID);
 
     merged_useLocaleStore.getState().setLocaleData(merged_DEFAULT_LOCALE_ID, {
       robots: [
@@ -379,6 +445,8 @@ describe('AudioEngine - audioMode enforcement (solo/mute/highlight)', () => {
   it('applies ~50% attenuation to non-highlighted robots when one is highlighted', async () => {
     const Tone = await import('tone');
     const { AudioEngine } = await import('./AudioEngine');
+    const helpers = await import('../utils/localeHelpers');
+    (helpers.getActiveLocaleId as ReturnType<typeof vi.fn>).mockReturnValue(merged_DEFAULT_LOCALE_ID);
 
     merged_useLocaleStore.getState().setLocaleData(merged_DEFAULT_LOCALE_ID, {
       robots: [

--- a/src/engine/AudioEngine.ts
+++ b/src/engine/AudioEngine.ts
@@ -848,6 +848,37 @@ export const AudioEngine = {
     return compositeVoices.get(robotId)?.composite ?? null;
   },
 
+  /**
+   * Deterministic re-reservation helper used by UI/store updates.
+   * Reads the robot's current `audioAttributes` from the locale store,
+   * calls `releaseVoice(robotId)` then `reserveVoice(...)` with the
+   * freshly-read `phase`, `detune`, and `pulseWidth` values so
+   * updates from the store are applied immediately to the reserved voice.
+   * Returns true when reservation succeeded.
+   */
+  reReserveVoice(robotId: string): boolean {
+    try {
+      const state = useLocaleStore.getState();
+      const robot = state.locales[getActiveLocaleId()]?.robots.find((r: { id: string }) => r.id === robotId);
+      if (!robot) return false;
+
+      const layered = (robot.audioAttributes as unknown as { visualAudioMap?: { layeredWave?: LayeredWave } })?.visualAudioMap?.layeredWave;
+      if (!layered) return false;
+
+      AudioEngine.releaseVoice(robotId);
+      return AudioEngine.reserveVoice(
+        robotId,
+        layered as LayeredWave,
+        robot.audioAttributes?.phase,
+        robot.audioAttributes?.detune,
+        robot.audioAttributes?.pulseWidth,
+      );
+    } catch (err) {
+      if (DEV_TUNING) swallow(err, 'AudioEngine.reReserveVoice');
+      return false;
+    }
+  },
+
 
   /**
    * Create a composite voice made of multiple layers (oscillators and optional noise).

--- a/src/systems/spawnSystem.test.ts
+++ b/src/systems/spawnSystem.test.ts
@@ -64,7 +64,7 @@ describe('spawnSystem', () => {
   describe('generateAudioAttributes', () => {
     it('generates valid synth type', () => {
       const attrs = generateAudioAttributes(mockNoiseMap, 0);
-      expect(['sine', 'square', 'triangle', 'sawtooth']).toContain(attrs.waveform);
+      expect(['sine', 'square', 'triangle', 'sawtooth', 'pulse']).toContain(attrs.waveform);
     });
 
     it('generates ADSR values in valid ranges', () => {
@@ -99,10 +99,10 @@ describe('spawnSystem', () => {
 
     it('generates varied attributes (not all the same)', () => {
       const attributes = Array.from({ length: 20 }, (_, i) => generateAudioAttributes(mockNoiseMap, i));
-        const uniqueWaveforms = new Set(attributes.map((a) => a.waveform));
+      const uniqueWaveforms = new Set(attributes.map((a) => a.waveform));
       const uniqueAttacks = new Set(attributes.map((a) => a.adsr.attack.toFixed(2)));
       // Synth type is now generic; ensure ADSR variety still exists
-        expect(uniqueWaveforms.size).toBeGreaterThan(1);
+      expect(uniqueWaveforms.size).toBeGreaterThan(1);
       expect(uniqueAttacks.size).toBeGreaterThan(10); // Should have variety
     });
 


### PR DESCRIPTION
 - Add reReserveVoice(robotId) to AudioEngine to release and re-reserve a robot's composite voice using the robot's current audioAttributes (layeredWave descriptor, phase, detune, pulseWidth).
 - Consolidate and repair AudioEngine unit tests in AudioEngine.test.ts:
  - Cast mocked useLocaleStore.getState() return as any to simplify fixtures used by the engine tests.
  - Populate mock robots with required fields (state, position, destination, direction, melody, octaveRange, masterVolume, audioMode, etc.) so TypeScript and runtime checks pass.
  - Align test locale usage so getActiveLocaleId() and setLocaleData() reference the same locale id, enabling audioMode (mute/solo/highlight) enforcement to be exercised.
  - Restore Vitest-compatible imports/mocks and tidy related test scaffolding.
 - Tests updated to verify re-reservation behavior and melody registration/unregistration flows.

 Closes #328
